### PR TITLE
Add missing custom post type args: "show_in_menu"

### DIFF
--- a/src/Foundation/WordPressCustomPostTypeServiceProvider.php
+++ b/src/Foundation/WordPressCustomPostTypeServiceProvider.php
@@ -324,6 +324,7 @@ abstract class WordPressCustomPostTypeServiceProvider extends ServiceProvider
       'exclude_from_search'  => $this->excludeFromSearch,
       'publicly_queryable'   => $this->publiclyQueryable,
       'show_ui'              => $this->showUI,
+      'show_in_menu'         => $this->showInMenu,
       'show_in_nav_menus'    => $this->showInNavMenus,
       'show_in_admin_bar'    => $this->showInAdminBar,
       'menu_position'        => $this->menuPosition,


### PR DESCRIPTION
The protected property `WordPressCustomPostTypeServiceProvider::showInMenu` was initialized in the class but not used in the custom post type registration