### PR TITLE
Allow null as option default value

### DIFF
--- a/src/Database/WordPressOption.php
+++ b/src/Database/WordPressOption.php
@@ -345,7 +345,7 @@ class WordPressOption implements ArrayAccess
 
     // search for delete
     foreach ($result as $key => $value) {
-      if (!is_numeric($key) && !isset($lastVersion[$key])) {
+      if (!is_numeric($key) && !array_key_exists($key, $lastVersion)) {
         unset($result[$key]);
       }
     }


### PR DESCRIPTION
Currently, if you set an option default value to `null` in your `config/option.php` file, every time you activate the plugin the value of that option is deleted, whatever the current value is.