### PR TITLE
support symlink inside wp-content/plugins

### DIFF
--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -600,7 +600,10 @@ namespace Bones {
         | We have to load the WordPress environment.
         |
         */
-        if (!file_exists(__DIR__ . '/../../../wp-load.php')) {
+        $currentDir = $_SERVER['PWD'] ?? __DIR__;
+        $wpLoadPath = dirname(dirname(dirname($currentDir))) . '/wp-load.php';
+
+        if (!file_exists($wpLoadPath)) {
           echo "\n\033[33;5;82mWarning!!\n";
           echo "\n\033[38;5;82m\t" .
             'You must be inside "wp-content/plugins/" folders';
@@ -608,7 +611,7 @@ namespace Bones {
           exit();
         }
 
-        require __DIR__ . '/../../../wp-load.php';
+        require $wpLoadPath;
       } catch (Exception $e) {
         echo "\n\033[33;5;82mWarning!!\n";
         echo "\n\033[38;5;82m\t" . 'Can\'t load WordPress';


### PR DESCRIPTION
When working with my plugins, I usually setup symlink from my plugin github repo to `wp-content/plugins` directory.

I need this setup to allow me to use this plugin repo on multiple WordPress install at the same time to cover multiple site scenario.

Unfortunately, this makes `php bones` does not work because it uses `__DIR__` and `/../../../` to get the main WordPress directory, that will always return the wrong directory because it always return the plugin repo directory.

To make it work, we use `$_SERVER['PWD']` fallback to `__DIR__` and use `dirname` to get the correct main WordPress directory.
