### PR TITLE
Fix Compatibility with macOS .DS_Store files

### DIFF
--- a/src/Routing/API/RestProvider.php
+++ b/src/Routing/API/RestProvider.php
@@ -72,7 +72,7 @@ class RestProvider extends ServiceProvider
     $contents = [];
 
     foreach (scandir($dir) as $node) {
-      if ($node == '.' || $node == '..') {
+      if ($node == '.' || $node == '..'||$node==".DS_Store") {
         continue;
       }
       if (is_dir($dir . '/' . $node)) {


### PR DESCRIPTION
macOS  generates a default .DS_Store file on every folder that was opened in Finder, this triggers a

```
Fatal error: Uncaught TypeError: Cannot access offset of type string on string in /path-to/vendor/wpbones/wpbones/src/Routing/API/RestProvider.php:81
Stack trace:
#0 /path-to/vendor/wpbones/wpbones/src/Routing/API/RestProvider.php(56): Bredecl\WPBones\Routing\API\RestProvider->dirToArray('/Users/bredebs/...')
#1 /path-to/vendor/wpbones/wpbones/src/Routing/API/RestProvider.php(28): Bredecl\WPBones\Routing\API\RestProvider->initCustomRoutes()
```
With this small fix the problem is solved, and also fix the error on activation.