### PR TITLE
Database extension

### DIFF
--- a/src/Database/DB.php
+++ b/src/Database/DB.php
@@ -122,8 +122,9 @@ class DB
         return Str::startsWith($name, $prefix) ? $name : $prefix . $name;
     }
 
-
-
+    /**
+     * Return the site-wide tables
+     */
     public static function getMultisiteTables(){
         global $wpdb;
         $prefix = is_multisite()? $wpdb->base_prefix : $wpdb->prefix;

--- a/src/Database/DB.php
+++ b/src/Database/DB.php
@@ -9,144 +9,168 @@ use WPKirk\WPBones\Support\Str;
  */
 class DB
 {
-  /**
-   * The query builder instance.
-   *
-   * @var \WPKirk\WPBones\Database\QueryBuilder
-   */
-  protected QueryBuilder $queryBuilder;
+    /**
+     * The query builder instance.
+     *
+     * @var \WPKirk\WPBones\Database\QueryBuilder
+     */
+    protected QueryBuilder $queryBuilder;
 
-  /**
-   * A key-value array of attributes of the attributes.
-   *
-   * @var array
-   */
-  public $attributes = [];
+    /**
+     * A key-value array of attributes of the attributes.
+     *
+     * @var array
+     */
+    public $attributes = [];
 
-  /**
-   * Will use the WordPress prefix of the database.
-   *
-   * @since 1.7.0
-   * @var bool
-   */
-  protected $usePrefix = true;
+    /**
+     * Will use the WordPress prefix of the database.
+     *
+     * @since 1.7.0
+     * @var bool
+     */
+    protected $usePrefix = true;
 
-  /**
-   * Create a new DB model.
-   *
-   * @param string $table The table name.
-   * @param string $primaryKey
-   * @param bool $usePrefix Optional. @since 1.7.0 you can set this to false to not use the WordPress prefix. Default is true.
-   */
-  public function __construct($table, $primaryKey = 'id', $usePrefix = true)
-  {
-    $this->usePrefix = $usePrefix;
-    $this->queryBuilder = new QueryBuilder($table, $primaryKey, $this->usePrefix);
-    $this->queryBuilder->setParentModel($this);
-  }
+    /**
+     * Create a new DB model.
+     *
+     * @param string $table The table name.
+     * @param string $primaryKey
+     * @param bool $usePrefix Optional. @since 1.7.0 you can set this to false to not use the WordPress prefix. Default is true.
+     */
+    public function __construct($table, $primaryKey = 'id', $usePrefix = true)
+    {
+        $this->usePrefix = $usePrefix;
+        $this->queryBuilder = new QueryBuilder($table, $primaryKey, $this->usePrefix);
+        $this->queryBuilder->setParentModel($this);
+    }
 
-  /*
-  |--------------------------------------------------------------------------
-  | Public static and instance methods
-  |--------------------------------------------------------------------------
-  |
-  |
-  */
+    /*
+    |--------------------------------------------------------------------------
+    | Public static and instance methods
+    |--------------------------------------------------------------------------
+    |
+    |
+     */
 
-  /**
-   * Instantiate a new DB model with the given table name.
-   *
-   * @param string $table The table name.
-   * @param string $primaryKey
-   * @param bool $usePrefix Optional. @since 1.7.0 you can set this to false to not use the WordPress prefix. Default is true.
-   *
-   * @see DB::tableWithoutPrefix()
-   *
-   * @return DB
-   */
-  public static function table(string $table, string $primaryKey = 'id', $usePrefix = true): DB
-  {
-    return new static($table, $primaryKey, $usePrefix);
-  }
+    /**
+     * Instantiate a new DB model with the given table name.
+     *
+     * @param string $table The table name.
+     * @param string $primaryKey
+     * @param bool $usePrefix Optional. @since 1.7.0 you can set this to false to not use the WordPress prefix. Default is true.
+     *
+     * @see DB::tableWithoutPrefix()
+     *
+     * @return DB
+     */
+    public static function table(string $table, string $primaryKey = 'id', $usePrefix = true): DB
+    {
+        return new static($table, $primaryKey, $usePrefix);
+    }
 
-  /**
-   * Instantiate a new DB model with the given table name without the WordPress prefix.
-   *
-   * @param string $table The table name.
-   * @param string $primaryKey
-   * @return DB
-   */
-  public static function tableWithoutPrefix(string $table, string $primaryKey = 'id'): DB
-  {
-    return new static($table, $primaryKey, false);
-  }
+    /**
+     * Instantiate a new DB model with the given table name without the WordPress prefix.
+     *
+     * @param string $table The table name.
+     * @param string $primaryKey
+     * @return DB
+     */
+    public static function tableWithoutPrefix(string $table, string $primaryKey = 'id'): DB
+    {
+        return new static($table, $primaryKey, false);
+    }
 
-  /**
-   * Return a WordPress table name with the WordPress prefix.
-   *
-   * @param string $class
-   * @param string $usePrefix Optional. @since 1.7.0 you can set this to false to not use the WordPress prefix.
-   *                          Default is true.
-   * @return string
-   *
-   * @example
-   *          Model::tableName('User') returns 'wp_users'
-   *          Model::tableName('WPMyTable') returns 'wp_w_p_my_table'
-   *          Model::tableName('WP_MyTable') returns 'wp_w_p_my_table'
-   *
-   * @since 1.7.0
-   * If you set the $usePrefix to false, it will not use the WordPress prefix.
-   * @example
-   *          Model::tableName('User', false) returns 'users'
-   *          Model::tableName('WPMyTable', false) returns 'wp_my_table'
-   *          Model::tableName('WP_MyTable', false) returns 'wp_my_table'
-   *
-   */
-  public static function getTableName(string $class, $usePrefix = true): string
-  {
-    global $wpdb;
+    /**
+     * Return a WordPress table name with the WordPress prefix.
+     *
+     * @param string $class
+     * @param string $usePrefix Optional. @since 1.7.0 you can set this to false to not use the WordPress prefix.
+     *                          Default is true.
+     * @param string $prefixParam Optional. You can set a custom defined prefix. Default is empty.
+     * @return string
+     *
+     * @example
+     *          Model::tableName('User') returns 'wp_users'
+     *          Model::tableName('WPMyTable') returns 'wp_w_p_my_table'
+     *          Model::tableName('WP_MyTable') returns 'wp_w_p_my_table'
+     *
+     * @since 1.7.0
+     * If you set the $usePrefix to false, it will not use the WordPress prefix.
+     * @example
+     *          Model::tableName('User', false) returns 'users'
+     *          Model::tableName('WPMyTable', false) returns 'wp_my_table'
+     *          Model::tableName('WP_MyTable', false) returns 'wp_my_table'
+     *
+     */
+    public static function getTableName(string $class, $usePrefix = true,$prefixParam=""): string
+    {
+        global $wpdb;
 
-    $paths = explode('\\', $class);
-    $only = array_pop($paths);
-    $name = Str::snake(Str::studly($only));
-    $prefix = $usePrefix ? $wpdb->prefix : '';
+        $paths = explode('\\', $class);
+        $only = array_pop($paths);
+        $name = Str::snake(Str::studly($only));
+        $WPMSTables = DB::getMultisiteTables();
+        #ddjson($WPMSTables);
+        if (is_multisite()) {
+            $prefix = $usePrefix ? $wpdb->prefix : $prefixParam;
+            $name = str_replace(str_replace( "_", "",$wpdb->base_prefix).get_current_blog_id()."_", "", $name);
+            $prefix=$usePrefix?(in_array($name,$WPMSTables)?$wpdb->base_prefix:$wpdb->prefix):$prefixParam;
+        } else {
+            $prefix = $usePrefix ? $wpdb->prefix : $prefixParam;
+        }
+        return Str::startsWith($name, $prefix) ? $name : $prefix . $name;
+    }
 
-    return Str::startsWith($name, $prefix) ? $name : $prefix . $name;
-  }
 
-  /*
-  |--------------------------------------------------------------------------
-  | Getter and setter
-  |--------------------------------------------------------------------------
-  |
-  |
-  */
 
-  /**
-   * Set the primary key for the model.
-   */
-  public function setPrimaryKey($primaryKey)
-  {
-    $this->queryBuilder->setPrimaryKey($primaryKey);
-  }
+    public static function getMultisiteTables(){
+        global $wpdb;
+        $prefix = is_multisite()? $wpdb->base_prefix : $wpdb->prefix;
+        return[
+            $prefix."blogs","blogs",
+            $prefix."blog_versions","blog_versions",
+            $prefix."registration_log","registration_log",
+            $prefix."signups","signups",
+            $prefix."site","site",
+            $prefix."sitemeta","sitemeta",
+            $prefix."users","users",
+            $prefix."usermeta","usermeta",
+        ];
+    }
+    /*
+    |--------------------------------------------------------------------------
+    | Getter and setter
+    |--------------------------------------------------------------------------
+    |
+    |
+     */
 
-  /*
-  |--------------------------------------------------------------------------
-  | Magic methods
-  |--------------------------------------------------------------------------
-  |
-  |
-  */
+    /**
+     * Set the primary key for the model.
+     */
+    public function setPrimaryKey($primaryKey)
+    {
+        $this->queryBuilder->setPrimaryKey($primaryKey);
+    }
 
-  /**
-   * Proxy method for the query builder.
-   *
-   * @param string $name      The method name.
-   * @param array  $arguments The method arguments.
-   */
-  public function __call(string $name, array $arguments)
-  {
-    // we're going to call the same queryBuilder methods
-    return call_user_func_array([$this->queryBuilder, $name], $arguments);
-  }
+    /*
+    |--------------------------------------------------------------------------
+    | Magic methods
+    |--------------------------------------------------------------------------
+    |
+    |
+     */
+
+    /**
+     * Proxy method for the query builder.
+     *
+     * @param string $name      The method name.
+     * @param array  $arguments The method arguments.
+     */
+    public function __call(string $name, array $arguments)
+    {
+        // we're going to call the same queryBuilder methods
+        return call_user_func_array([$this->queryBuilder, $name], $arguments);
+    }
 }

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -18,6 +18,13 @@ abstract class Model extends DB
    * @var string
    */
   protected $table;
+  /**
+   * The table's prefix
+   *
+   * @var string
+   */
+  protected $prefix;
+
 
   /**
    * The primary key for the model.
@@ -29,9 +36,9 @@ abstract class Model extends DB
   public function __construct()
   {
     // get the class name
-    $this->table = DB::getTableName($this->table ?? get_called_class(), $this->usePrefix);
+    $this->table = DB::getTableName($this->table ?? get_called_class(), $this->usePrefix,$this->prefix);
 
-    parent::__construct($this->table, $this->primaryKey, $this->usePrefix);
+    parent::__construct($this->table, $this->primaryKey, $this->usePrefix,$this->prefix);
   }
 
   /*

--- a/src/Database/QueryBuilder.php
+++ b/src/Database/QueryBuilder.php
@@ -11,937 +11,988 @@ use WPKirk\WPBones\Database\Support\Model;
  */
 class QueryBuilder
 {
-  /**
-   * The database table name.
-   *
-   * @var string
-   */
-  protected $table;
-
-
-  /**
-   * The primary key column name.
-   *
-   * @var string
-   */
-  protected $primaryKey = 'id';
-
-  /**
-   * The WordPress database object.
-   *
-   * @var \wpdb
-   */
-  protected $wpdb;
-
-  /**
-   * List of columns and their types.
-   * That is the desc of the table.
-   *
-   * @var array
-   */
-  private $columns = [];
-
-  /**
-   * The select columns.
-   */
-  private $select_columns = [];
-
-  /**
-   * The orderings for the query.
-   *
-   * @var array
-   */
-  private $orders = [];
-
-  /**
-   * The maximum number of records to return.
-   *
-   * @var int
-   */
-  private $limit = '';
-
-  /**
-   * The number of records to skip.
-   *
-   * @var int
-   */
-  private $offset;
-
-  /**
-   * The where conditions for the query.
-   *
-   * @var array
-   */
-  private $wheres = [];
-
-  /**
-   * All the available clause operators.
-   *
-   * @var array
-   */
-  private $operators = [
-    '=',
-    '<',
-    '>',
-    '<=',
-    '>=',
-    '<>',
-    '!=',
-    '<=>',
-    'like',
-    'like binary',
-    'not like',
-    'ilike',
-    '&',
-    '|',
-    '^',
-    '<<',
-    '>>',
-    'rlike',
-    'not rlike',
-    'regexp',
-    'not regexp',
-    '~',
-    '~*',
-    '!~',
-    '!~*',
-    'similar to',
-    'not similar to',
-    'not ilike',
-    '~~*',
-    '!~~*',
-  ];
-
-  /**
-   * The collection of rows.
-   *
-   * @var \WPKirk\WPBones\Database\Support\Collection
-   */
-  private $collection = [];
-
-  /**
-   * The parent model instance used for extends the Model class.
-   */
-  private $parentModel;
-
-  /**
-   * The constructor.
-   *
-   * @param string $table The table name.
-   * @param string $primaryKey The primary key column name.
-   * @param bool $usePrefix Optional. @since 1.7.0 - Will use the WordPress prefix of the database. Default is true.
-   * @return void         The QueryBuilder instance.
-   */
-  public function __construct($table, $primaryKey = 'id', $usePrefix = true)
-  {
-    global $wpdb;
-
-    $this->wpdb = $wpdb;
-    $this->table = DB::getTableName($table, $usePrefix);
-    $this->primaryKey = $primaryKey;
-
-    // init
-    $this->getTableDescription();
-  }
-
-  /*
-  |--------------------------------------------------------------------------
-  | Magic methods
-  |--------------------------------------------------------------------------
-  |
-  |
-  */
-
-  /*
-  |--------------------------------------------------------------------------
-  | Public methods
-  |--------------------------------------------------------------------------
-  |
-  |
-  */
-
-  /**
-   * Get the table description.
-   *
-   * @return void
-   */
-  protected function getTableDescription()
-  {
-    if (!empty($this->table)) {
-      $desc = $this->wpdb->get_results("DESC `{$this->table}`");
-
-      /**
-       * [0] => stdClass Object
-       *      (
-       *          [Field] => ID
-       *          [Type] => bigint(20) unsigned
-       *          [Null] => NO
-       *          [Key] => PRI
-       *          [Default] =>
-       *          [Extra] => auto_increment
-       *      )
-       *
-       *  [1] => stdClass Object
-       *      (
-       *          [Field] => user_login
-       *          [Type] => varchar(60)
-       *          [Null] => NO
-       *          [Key] => MUL
-       *          [Default] =>
-       *          [Extra] =>
-       *      )
-       */
-
-      foreach ($desc as $column) {
-        $this->columns[] = [
-          'name' => $column->Field,
-          'type' => $column->Type,
-          'null' => $column->Null,
-          'key' => $column->Key,
-          'default' => $column->Default,
-          'extra' => $column->Extra,
-        ];
-      }
-
-      /**
-       * [0] => Array
-       *      (
-       *          [name] => ID
-       *          [type] => bigint(20) unsigned
-       *          [null] => NO
-       *          [key] => PRI
-       *          [default] =>
-       *          [extra] => auto_increment
-       *      )
-       *
-       *  [1] => Array
-       *      (
-       *          [name] => user_login
-       *          [type] => varchar(60)
-       *          [null] => NO
-       *          [key] => MUL
-       *          [default] =>
-       *          [extra] =>
-       *      )
-       */
-    }
-  }
-
-  /**
-   * Return a collection of records that match the given where conditions.
-   *
-   * @return Collection
-   */
-  public function get()
-  {
-    return $this->all();
-  }
-
-  /**
-   * Return a collection of all the records.
-   *
-   * @return Collection
-   */
-  public function all($columns = ['*'])
-  {
-    $columns = $this->select_columns ?: $columns;
-    sort($columns);
-    $column_string = is_array($columns) ? implode(',', $columns) : implode(',', func_get_args());
-
-    $sql =
-      "SELECT $column_string " .
-      "FROM `{$this->table}`" .
-      $this->getWhere() .
-      $this->getOrderBy() .
-      $this->getLimit() .
-      $this->getOffset();
-
-    $results = $this->getSQLResults($sql);
+    /**
+     * The database table name.
+     *
+     * @var string
+     */
+    protected $table;
+    protected $prefix;
 
     /**
-     *     [0] => stdClass Object
-     *      (
-     *          [log_id] => 1
-     *          [user_id] => 1
-     *          [activity] => updated
-     *          [object_id] => 0
-     *          [object_type] => post
-     *          [activity_date] => 2019-05-03 00:00:00
-     *      )
-     *      ...
+     * The primary key column name.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'id';
+
+    /**
+     * The WordPress database object.
+     *
+     * @var \wpdb
+     */
+    protected $wpdb;
+
+    /**
+     * List of columns and their types.
+     * That is the desc of the table.
+     *
+     * @var array
+     */
+    private $columns = [];
+
+/**
+ * List of joins
+ *
+ * @var array
+ */
+    private $join = [];
+
+    /**
+     * The select columns.
+     */
+    private $select_columns = [];
+
+    /**
+     * The orderings for the query.
+     *
+     * @var array
+     */
+    private $orders = [];
+
+    /**
+     * The maximum number of records to return.
+     *
+     * @var int
+     */
+    private $limit = '';
+
+    /**
+     * The number of records to skip.
+     *
+     * @var int
+     */
+    private $offset;
+
+    /**
+     * The where conditions for the query.
+     *
+     * @var array
+     */
+    private $wheres = [];
+
+    /**
+     * All the available clause operators.
+     *
+     * @var array
+     */
+    private $operators = [
+        '=',
+        '<',
+        '>',
+        '<=',
+        '>=',
+        '<>',
+        '!=',
+        '<=>',
+        'like',
+        'like binary',
+        'not like',
+        'ilike',
+        '&',
+        '|',
+        '^',
+        '<<',
+        '>>',
+        'rlike',
+        'not rlike',
+        'regexp',
+        'not regexp',
+        '~',
+        '~*',
+        '!~',
+        '!~*',
+        'similar to',
+        'not similar to',
+        'not ilike',
+        '~~*',
+        '!~~*',
+    ];
+
+    /**
+     * The collection of rows.
+     *
+     * @var \WPKirk\WPBones\Database\Support\Collection
+     */
+    private $collection = [];
+
+    /**
+     * The parent model instance used for extends the Model class.
+     */
+    private $parentModel;
+
+    /**
+     * The constructor.
+     *
+     * @param string $table The table name.
+     * @param string $primaryKey The primary key column name.
+     * @param bool $usePrefix Optional. @since 1.7.0 - Will use the WordPress prefix of the database. Default is true.
+     * @return void         The QueryBuilder instance.
+     */
+    public function __construct($table, $primaryKey = 'id', $usePrefix = true)
+    {
+        global $wpdb;
+        $this->wpdb = $wpdb;
+        $this->table = DB::getTableName($table, $usePrefix, $this->prefix);
+        $this->primaryKey = $primaryKey;
+
+        // init
+        $this->getTableDescription();
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Magic methods
+    |--------------------------------------------------------------------------
+    |
+    |
      */
 
-    $collection = [];
-    foreach ($results as $result) {
-      $collection[] = new Model($result, $this);
+    /*
+    |--------------------------------------------------------------------------
+    | Public methods
+    |--------------------------------------------------------------------------
+    |
+    |
+     */
+
+    /**
+     * Get the table description.
+     *
+     * @return void
+     */
+    protected function getTableDescription()
+    {
+        if (!empty($this->table)) {
+            $desc = $this->wpdb->get_results("DESC `{$this->table}`");
+
+            /**
+             * [0] => stdClass Object
+             *      (
+             *          [Field] => ID
+             *          [Type] => bigint(20) unsigned
+             *          [Null] => NO
+             *          [Key] => PRI
+             *          [Default] =>
+             *          [Extra] => auto_increment
+             *      )
+             *
+             *  [1] => stdClass Object
+             *      (
+             *          [Field] => user_login
+             *          [Type] => varchar(60)
+             *          [Null] => NO
+             *          [Key] => MUL
+             *          [Default] =>
+             *          [Extra] =>
+             *      )
+             */
+
+            foreach ($desc as $column) {
+                $this->columns[] = [
+                    'name' => $column->Field,
+                    'type' => $column->Type,
+                    'null' => $column->Null,
+                    'key' => $column->Key,
+                    'default' => $column->Default,
+                    'extra' => $column->Extra,
+                ];
+            }
+
+            /**
+             * [0] => Array
+             *      (
+             *          [name] => ID
+             *          [type] => bigint(20) unsigned
+             *          [null] => NO
+             *          [key] => PRI
+             *          [default] =>
+             *          [extra] => auto_increment
+             *      )
+             *
+             *  [1] => Array
+             *      (
+             *          [name] => user_login
+             *          [type] => varchar(60)
+             *          [null] => NO
+             *          [key] => MUL
+             *          [default] =>
+             *          [extra] =>
+             *      )
+             */
+        }
     }
 
-    $this->collection = new Collection($collection);
+    /**
+     * Return a collection of records that match the given where conditions.
+     *
+     * @return Collection
+     */
+    public function get()
+    {
 
-    //error_log(print_r($this->collection, true));
-
-    // reset the where conditions
-    //$this->wheres = [];
-
-    return $this->collection;
-  }
-
-  /**
-   * Return the "where" part of the query.
-   *
-   * @return string
-   */
-  private function getWhere()
-  {
-    $where = ' WHERE 1 ';
-    if (!empty($this->wheres)) {
-      foreach ($this->wheres as $where_item) {
-        $boolean = strtoupper($where_item['boolean']);
-        $column = $where_item['column'];
-        $operator = $this->getWhereOperator($where_item['operator']);
-        $value = $this->getWhereValue($where_item['value'], $operator);
-
-        $where .= $boolean . ' ' . $column . ' ' . $operator . ' ' . $value . ' ';
-      }
+        return $this->all();
     }
 
-    return $where;
-  }
+    /**
+     * Return a collection of all the records.
+     *
+     * @return Collection
+     */
+    public function all($columns = ['*'])
+    {
+        $columns = $this->select_columns ?: $columns;
+        sort($columns);
+        $column_string = is_array($columns) ? implode(',', $columns) : implode(',', func_get_args());
 
-  /**
-   * Return the operator for the where clause.
-   *
-   * @param string $operator
-   */
-  private function getWhereOperator($operator)
-  {
-    return $operator ?? '=';
-  }
+        $sql =
+        "SELECT $column_string " .
+        "FROM `{$this->table}`" .
+        $this->getJoin() .
+        $this->getWhere() .
+        $this->getOrderBy() .
+        $this->getLimit() .
+        $this->getOffset();
+        $results = $this->getSQLResults($sql);
 
-  /**
-   * Return the right format for the where value.
-   *
-   * @param string $value    The value to format.
-   * @param string $operator Type of operator.
-   */
-  private function getWhereValue($value, $operator)
-  {
-    if (is_array($value) && in_array($operator, ['IN', 'NOT IN'])) {
-      return '(' . implode(',', $value) . ')';
+        /**
+         *     [0] => stdClass Object
+         *      (
+         *          [log_id] => 1
+         *          [user_id] => 1
+         *          [activity] => updated
+         *          [object_id] => 0
+         *          [object_type] => post
+         *          [activity_date] => 2019-05-03 00:00:00
+         *      )
+         *      ...
+         */
+
+        $collection = [];
+        foreach ($results as $result) {
+            $collection[] = new Model($result, $this);
+        }
+
+        $this->collection = new Collection($collection);
+
+        #error_log(print_r($this->collection, true));
+
+        // reset the where conditions
+        //$this->wheres = [];
+
+        return $this->collection;
     }
 
-    if (is_array($value) && in_array($operator, ['BETWEEN'])) {
-      return implode(' AND ', $this->getFormatValue($value));
+    /**
+     * Return the "join" part of the query.
+     *
+     * @return string
+     */
+    private function getJoin()
+    {
+        $joins = '';
+        if (!empty($this->join)) {
+            foreach ($this->join as $join) {
+                $joins .= $join;
+            }
+        }
+
+        return $joins;
     }
 
-    return $this->getFormatValue($value);
-  }
+    /**
+     * Return the "where" part of the query.
+     *
+     * @return string
+     */
+    private function getWhere()
+    {
+        $where = ' ';
+        if (!empty($this->wheres)) {
+            $where = ' WHERE 1 ';
+            foreach ($this->wheres as $where_item) {
+                $boolean = strtoupper($where_item['boolean']);
+                $column = $where_item['column'];
+                $operator = $this->getWhereOperator($where_item['operator']);
+                $value = $this->getWhereValue($where_item['value'], $operator);
 
-  /**
-   * Return the right format for the value.
-   *
-   * @param mixed $value The value to format.
-   * @return mixed
-   */
-  private function getFormatValue($value)
-  {
-    if (is_array($value)) {
-      return array_map(function ($value) {
+                $where .= $boolean . ' ' . $column . ' ' . $operator . ' ' . $value . ' ';
+            }
+        }
+
+        return $where;
+    }
+
+    /**
+     * Return the operator for the where clause.
+     *
+     * @param string $operator
+     */
+    private function getWhereOperator($operator)
+    {
+        return $operator ?? '=';
+    }
+
+    /**
+     * Return the right format for the where value.
+     *
+     * @param string $value    The value to format.
+     * @param string $operator Type of operator.
+     */
+    private function getWhereValue($value, $operator)
+    {
+        if (is_array($value) && in_array($operator, ['IN', 'NOT IN'])) {
+            return '(' . implode(',', $value) . ')';
+        }
+
+        if (is_array($value) && in_array($operator, ['BETWEEN'])) {
+            return implode(' AND ', $this->getFormatValue($value));
+        }
+
         return $this->getFormatValue($value);
-      }, $value);
     }
 
-    return is_numeric($value) ? $value : "'" . $value . "'";
-  }
-
-  /**
-   * Return the "order by" clause.
-   *
-   * @return string
-   */
-  private function getOrderBy()
-  {
-    if (!empty($this->orders)) {
-      $orders = [];
-      foreach ($this->orders as $order) {
-        $orders[] = $order[0] . ' ' . $order[1];
-      }
-
-      return ' ORDER BY ' . implode(',', $orders);
-    }
-
-    return '';
-  }
-
-  /**
-   * Return the "limit" clause.
-   *
-   * @return string
-   */
-  private function getLimit()
-  {
-    if (!empty($this->limit)) {
-      return ' LIMIT ' . $this->limit;
-    }
-
-    return '';
-  }
-
-  /**
-   * Return the "offset" clause.
-   *
-   * @return string
-   */
-  private function getOffset()
-  {
-    if (!empty($this->offset)) {
-      $offset = max(0, (int) $this->offset);
-      if ($offset > 0) {
-        if (empty($this->limit)) {
-          return ' LIMIT 18446744073709551615 OFFSET ' . $offset;
+    /**
+     * Return the right format for the value.
+     *
+     * @param mixed $value The value to format.
+     * @return mixed
+     */
+    private function getFormatValue($value)
+    {
+        if (is_array($value)) {
+            return array_map(function ($value) {
+                return $this->getFormatValue($value);
+            }, $value);
         }
-      }
 
-      return ' OFFSET ' . $offset;
+        return is_numeric($value) ? $value : "'" . $value . "'";
     }
 
-    return '';
-  }
+    /**
+     * Return the "order by" clause.
+     *
+     * @return string
+     */
+    private function getOrderBy()
+    {
+        if (!empty($this->orders)) {
+            $orders = [];
+            foreach ($this->orders as $order) {
+                $orders[] = $order[0] . ' ' . $order[1];
+            }
 
-  /**
-   * Execute a wpdb->get_results() query.
-   *
-   * @return array
-   */
-  protected function getSQLResults($sql, $type = ARRAY_A)
-  {
-    $results = $this->wpdb->get_results($sql, $type);
-
-    return $results;
-  }
-
-  /**
-   * Return the last record that matches the given where conditions.
-   *
-   * @return Model
-   */
-  public function last()
-  {
-    $this->limit(1);
-    $this->orderBy($this->primaryKey, 'desc');
-    $this->all();
-
-    return $this->collection->first();
-  }
-
-  /**
-   * Set the limit "limit" clause for the query.
-   */
-  public function limit($value = 1)
-  {
-    $this->limit = max(1, (int) $value);
-
-    return $this;
-  }
-
-  /**
-   * Set the "order by" clause for the query.
-   */
-  public function orderBy($column, $order = 'asc')
-  {
-    $order = strtolower($order);
-
-    $this->orders[] = [$column, $order];
-
-    return $this;
-  }
-
-  /**
-   * Return the first record that matches the given where conditions.
-   *
-   * @return Model
-   */
-  public function first()
-  {
-    $this->limit(1);
-    $this->all();
-
-    return $this->collection->first();
-  }
-
-  /**
-   * Return the record with the given id.
-   *
-   * @return Model
-   */
-  public function find($id)
-  {
-    $this->where($this->primaryKey, $id);
-
-    return $this->first();
-  }
-
-  /**
-   * Add a where condition to the query.
-   *
-   * @param string $column   The column name.
-   * @param string $operator The operator.
-   * @param mixed  $value    The value.
-   * @param string $boolean  The boolean operator.
-   */
-  public function where($column, $operator = null, $value = null, $boolean = 'and')
-  {
-    if (is_array($column)) {
-      if (count($column) !== count($column, COUNT_RECURSIVE)) {
-        foreach ($column as $where_array) {
-          $this->where($where_array);
+            return ' ORDER BY ' . implode(',', $orders);
         }
-      } else {
-        if (count($column) == 2) {
-          [$c, $v] = $column;
-          $this->where($c, $v);
-        } else {
-          [$c, $o, $v] = $column;
-          $this->where($c, $o, $v);
-        }
-      }
 
-      return $this;
+        return '';
     }
 
-    [$value, $operator] = $this->prepareValueAndOperator($value, $operator, func_num_args() === 2);
+    /**
+     * Return the "limit" clause.
+     *
+     * @return string
+     */
+    private function getLimit()
+    {
+        if (!empty($this->limit)) {
+            return ' LIMIT ' . $this->limit;
+        }
 
-    $this->wheres[] = compact('column', 'operator', 'value', 'boolean');
-
-    //error_log(print_r($this->wheres, true));
-    //error_log(print_r($this->getWhere(), true));
-
-    return $this;
-  }
-
-  /**
-   * Return the value and operator for the query.
-   *
-   * @param mixed  $value
-   * @param string $operator
-   * @param bool   $useDefault
-   *
-   * @return array
-   */
-  private function prepareValueAndOperator($value, $operator, $useDefault = false)
-  {
-    if ($useDefault) {
-      return [$operator, '='];
-    } elseif ($this->invalidOperatorAndValue($operator, $value)) {
-      throw new InvalidArgumentException('Illegal operator and value combination.');
+        return '';
     }
 
-    return [$value, $operator];
-  }
+    /**
+     * Return the "offset" clause.
+     *
+     * @return string
+     */
+    private function getOffset()
+    {
+        if (!empty($this->offset)) {
+            $offset = max(0, (int) $this->offset);
+            if ($offset > 0) {
+                if (empty($this->limit)) {
+                    return ' LIMIT 18446744073709551615 OFFSET ' . $offset;
+                }
+            }
 
-  /**
-   * Determine if the given operator and value combination is legal.
-   *
-   * Prevents using Null values with invalid operators.
-   *
-   * @param string $operator
-   * @param mixed  $value
-   * @return bool
-   */
-  protected function invalidOperatorAndValue($operator, $value)
-  {
-    return is_null($value) && in_array($operator, $this->operators) && !in_array($operator, ['=', '<>', '!=']);
-  }
-
-  /**
-   * Return the values of a single column.
-   *
-   * @param string $column_name
-   * @return array
-   */
-  public function pluck($column_name)
-  {
-    $this->select($column_name);
-    $this->all();
-
-    return array_map(function ($item) use ($column_name) {
-      return $item->$column_name;
-    }, $this->collection->getArrayCopy());
-  }
-
-  /**
-   * Set the select columns for the query.
-   *
-   * @param array|string $columns The columns to select.
-   */
-  public function select($columns = [])
-  {
-    $columns = is_array($columns) ? $columns : func_get_args();
-    $this->select_columns = $columns;
-
-    return $this;
-  }
-
-  /**
-   * Delete one or more records.
-   */
-  public function delete()
-  {
-    $sql = 'DELETE ' . "FROM `{$this->table}`" . $this->getWhere();
-
-    $this->wpdb->query($sql);
-
-    return $this;
-  }
-
-  /**
-   * Execute a wpdb->query() query.
-   *
-   * @return mixed
-   */
-  protected function query($sql)
-  {
-    return $this->wpdb->query($sql);
-  }
-
-  /**
-   * Add an "or where" condition to the query.
-   */
-  public function orWhere($column, $operator = null, $value = null, $boolean = 'or')
-  {
-    if (is_array($column)) {
-      if (count($column) !== count($column, COUNT_RECURSIVE)) {
-        foreach ($column as $where_array) {
-          $this->orWhere($where_array);
+            return ' OFFSET ' . $offset;
         }
-      } else {
-        if (count($column) == 2) {
-          [$c, $v] = $column;
-          $this->orWhere($c, $v);
-        } else {
-          [$c, $o, $v] = $column;
-          $this->orWhere($c, $o, $v);
-        }
-      }
 
-      return $this;
+        return '';
     }
 
-    [$value, $operator] = $this->prepareValueAndOperator($value, $operator, func_num_args() === 2);
+    /**
+     * Execute a wpdb->get_results() query.
+     *
+     * @return array
+     */
+    protected function getSQLResults($sql, $type = ARRAY_A)
+    {
+        $results = $this->wpdb->get_results($sql, $type);
 
-    $this->wheres[] = compact('column', 'operator', 'value', 'boolean');
+        return $results;
+    }
 
-    //error_log(print_r($this->wheres, true));
-    //error_log(print_r($this->getWhere(), true));
+    /**
+     * Return the last record that matches the given where conditions.
+     *
+     * @return Model
+     */
+    public function last()
+    {
+        $this->limit(1);
+        $this->orderBy($this->primaryKey, 'desc');
+        $this->all();
 
-    return $this;
-  }
+        return $this->collection->first();
+    }
 
-  /*
-     |--------------------------------------------------------------------------
-     | Internal Methods
-     |--------------------------------------------------------------------------
-     |
-     |
-     |
+    /**
+     * Set the limit "limit" clause for the query.
+     */
+    public function limit($value = 1)
+    {
+        $this->limit = max(1, (int) $value);
+
+        return $this;
+    }
+
+    /**
+     * Set the "order by" clause for the query.
+     */
+    public function orderBy($column, $order = 'asc')
+    {
+        $order = strtolower($order);
+
+        $this->orders[] = [$column, $order];
+
+        return $this;
+    }
+
+    /**
+     * Return the first record that matches the given where conditions.
+     *
+     * @return Model
+     */
+    public function first()
+    {
+        $this->limit(1);
+        $this->all();
+
+        return $this->collection->first();
+    }
+
+    /**
+     * Return the record with the given id.
+     *
+     * @return Model
+     */
+    public function find($id)
+    {
+        $this->where($this->primaryKey, $id);
+
+        return $this->first();
+    }
+
+    /**
+     * Add a join relationship to the query
+     *
+     * @param string $foreignTable   The Foreign table name
+     * @param string $foreignColumn The Foreign column name
+     * @param string $operator    The operator for the join.
+     * @param string $column  The local column name.
+     * @param string $joinType  The join type (inner, left, right, etc), by default join.
+     * @return Model
+     */
+    public function join($foreignTable, $foreignColumn, $operator, $column, $joinType = "join")
+    {
+        $this->join[] = " {$joinType} `{$foreignTable}` on " . (str_contains($foreignColumn, $foreignTable) ? "" : "{$foreignTable}.") . "{$foreignColumn} = {$this->table}.{$column} ";
+
+        return $this;
+    }
+    /**
+     * Add a where condition to the query.
+     *
+     * @param string $column   The column name.
+     * @param string $operator The operator.
+     * @param mixed  $value    The value.
+     * @param string $boolean  The boolean operator.
+     */
+    public function where($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        if (is_array($column)) {
+            if (count($column) !== count($column, COUNT_RECURSIVE)) {
+                foreach ($column as $where_array) {
+                    $this->where($where_array);
+                }
+            } else {
+                if (count($column) == 2) {
+                    [$c, $v] = $column;
+                    $this->where($c, $v);
+                } else {
+                    [$c, $o, $v] = $column;
+                    $this->where($c, $o, $v);
+                }
+            }
+
+            return $this;
+        }
+
+        [$value, $operator] = $this->prepareValueAndOperator($value, $operator, func_num_args() === 2);
+
+        $this->wheres[] = compact('column', 'operator', 'value', 'boolean');
+
+        //error_log(print_r($this->wheres, true));
+        //error_log(print_r($this->getWhere(), true));
+
+        return $this;
+    }
+
+    /**
+     * Return the value and operator for the query.
+     *
+     * @param mixed  $value
+     * @param string $operator
+     * @param bool   $useDefault
+     *
+     * @return array
+     */
+    private function prepareValueAndOperator($value, $operator, $useDefault = false)
+    {
+        if ($useDefault) {
+            return [$operator, '='];
+        } elseif ($this->invalidOperatorAndValue($operator, $value)) {
+            throw new InvalidArgumentException('Illegal operator and value combination.');
+        }
+
+        return [$value, $operator];
+    }
+
+    /**
+     * Determine if the given operator and value combination is legal.
+     *
+     * Prevents using Null values with invalid operators.
+     *
+     * @param string $operator
+     * @param mixed  $value
+     * @return bool
+     */
+    protected function invalidOperatorAndValue($operator, $value)
+    {
+        return is_null($value) && in_array($operator, $this->operators) && !in_array($operator, ['=', '<>', '!=']);
+    }
+
+    /**
+     * Return the values of a single column.
+     *
+     * @param string $column_name
+     * @return array
+     */
+    public function pluck($column_name)
+    {
+        $this->select($column_name);
+        $this->all();
+
+        return array_map(function ($item) use ($column_name) {
+            return $item->$column_name;
+        }, $this->collection->getArrayCopy());
+    }
+
+    /**
+     * Set the select columns for the query.
+     *
+     * @param array|string $columns The columns to select.
+     */
+    public function select($columns = [])
+    {
+        $columns = is_array($columns) ? $columns : func_get_args();
+        $this->select_columns = $columns;
+
+        return $this;
+    }
+/**
+ * Set a raw query command for select
+ *
+ * @param array|string $columns The columns to select.
+ */
+    public function selectRaw($command)
+    {
+        $this->select_columns[] = $command;
+        return $this;
+    }
+
+    /**
+     * Delete one or more records.
+     */
+    public function delete()
+    {
+        $sql = 'DELETE ' . "FROM `{$this->table}`" . $this->getWhere();
+
+        $this->wpdb->query($sql);
+
+        return $this;
+    }
+
+    /**
+     * Execute a wpdb->query() query.
+     *
+     * @return mixed
+     */
+    protected function query($sql)
+    {
+        return $this->wpdb->query($sql);
+    }
+
+    /**
+     * Add an "or where" condition to the query.
+     */
+    public function orWhere($column, $operator = null, $value = null, $boolean = 'or')
+    {
+        if (is_array($column)) {
+            if (count($column) !== count($column, COUNT_RECURSIVE)) {
+                foreach ($column as $where_array) {
+                    $this->orWhere($where_array);
+                }
+            } else {
+                if (count($column) == 2) {
+                    [$c, $v] = $column;
+                    $this->orWhere($c, $v);
+                } else {
+                    [$c, $o, $v] = $column;
+                    $this->orWhere($c, $o, $v);
+                }
+            }
+
+            return $this;
+        }
+
+        [$value, $operator] = $this->prepareValueAndOperator($value, $operator, func_num_args() === 2);
+
+        $this->wheres[] = compact('column', 'operator', 'value', 'boolean');
+
+        //error_log(print_r($this->wheres, true));
+        //error_log(print_r($this->getWhere(), true));
+
+        return $this;
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Internal Methods
+    |--------------------------------------------------------------------------
+    |
+    |
+    |
      */
 
-  /**
-   * Add a where IN condition to the query.
-   *
-   * @param string       $column The column name.
-   * @param array|string $value  The values.
-   */
-  public function orWhereIn($column, $value)
-  {
-    return $this->whereIn($column, $value, 'or');
-  }
-
-  /**
-   * Add a where IN condition to the query.
-   *
-   * @param string       $column The column name.
-   * @param string|array $value
-   * @param string       $boolean
-   * @return \WPKirk\WPBones\Database\QueryBuilder
-   */
-  public function whereIn($column, $value, $boolean = 'and')
-  {
-    $value = is_string($value) ? explode(',', $value) : $value;
-    $operator = 'IN';
-    $this->wheres[] = compact('column', 'operator', 'value', 'boolean');
-
-    return $this;
-  }
-
-  /**
-   * Add a where NOT IN condition to the query.
-   *
-   * @param string       $column The column name.
-   * @param string|array $value  The values.
-   */
-  public function orWhereNotIn($column, $value)
-  {
-    return $this->whereNotIn($column, $value, 'or');
-  }
-
-  /**
-   * Add a where NOT IN condition to the query.
-   *
-   * @param string       $column The column name.
-   * @param array|string $value  The values.
-   */
-  public function whereNotIn($column, $value, $boolean = 'and')
-  {
-    $value = is_string($value) ? explode(',', $value) : $value;
-    $operator = 'NOT IN';
-    $this->wheres[] = compact('column', 'operator', 'value', 'boolean');
-
-    return $this;
-  }
-
-  /**
-   * Add a where BETWEEN condition to the query.
-   *
-   * @param string       $column The column name.
-   * @param array|string $value  The values.
-   */
-  public function orWhereBetween($column, $value)
-  {
-    return $this->whereBetween($column, $value, 'or');
-  }
-
-  /**
-   * Add a where BETWEEN condition to the query.
-   *
-   * @param string       $column The column name.
-   * @param array|string $value  The values.
-   */
-  public function whereBetween($column, $value, $boolean = 'and')
-  {
-    $value = is_string($value) ? explode(',', $value) : $value;
-    $operator = 'BETWEEN';
-    $this->wheres[] = compact('column', 'operator', 'value', 'boolean');
-
-    return $this;
-  }
-
-  /**
-   * Add a where NOT BETWEEN condition to the query.
-   *
-   * @param string       $column The column name.
-   * @param array|string $value  The values.
-   */
-  public function orWhereNotBetween($column, $value)
-  {
-    return $this->whereNotBetween($column, $value, 'or');
-  }
-
-  /**
-   * Add a where NOT BETWEEN condition to the query.
-   *
-   * @param string       $column The column name.
-   * @param array|string $value  The values.
-   */
-  public function whereNotBetween($column, $value, $boolean = 'and')
-  {
-    $value = is_string($value) ? explode(',', $value) : $value;
-    $operator = 'NOT BETWEEN';
-    $this->wheres[] = compact('column', 'operator', 'value', 'boolean');
-
-    return $this;
-  }
-
-  /**
-   * Set the offset "limit" clause for the query.
-   */
-  public function offset($value = 0)
-  {
-    $this->offset = max(0, (int) $value);
-
-    return $this;
-  }
-
-  /**
-   * Return a single column's value from the first result of the query.
-   *
-   * @return mixed
-   */
-  public function value($attribute)
-  {
-    return $this->first()->$attribute;
-  }
-
-  /**
-   * Return the count of the records that match the given where conditions.
-   *
-   * @return int
-   */
-  public function count()
-  {
-    $sql =
-      'SELECT COUNT(*) ' .
-      "FROM `{$this->table}`" .
-      $this->getWhere() .
-      $this->getOrderBy() .
-      $this->getLimit() .
-      $this->getOffset();
-
-    return $this->var($sql);
-  }
-
-  /**
-   * Execute a wpdb->get_var() query.
-   *
-   * @return mixed
-   */
-  protected function var($sql)
-  {
-    return $this->wpdb->get_var($sql);
-  }
-
-  /*
-     |--------------------------------------------------------------------------
-     | wpdb wrapper
-     |--------------------------------------------------------------------------
-     |
-     |
+    /**
+     * Add a where IN condition to the query.
+     *
+     * @param string       $column The column name.
+     * @param array|string $value  The values.
      */
-
-  /**
-   * Insert one or more records.
-   *
-   * @param array $values The data to insert.
-   *
-   * @return int|array The inserted id.
-   */
-  public function insert($values)
-  {
-    // here we can get a single or multiple array of values
-    if (count($values) !== count($values, COUNT_RECURSIVE)) {
-      $ids = [];
-      foreach ($values as $value) {
-        $ids[] = $this->insert($value);
-      }
-
-      return $ids;
+    public function orWhereIn($column, $value)
+    {
+        return $this->whereIn($column, $value, 'or');
     }
 
-    $columns = array_keys($values);
+    /**
+     * Add a where IN condition to the query.
+     *
+     * @param string       $column The column name.
+     * @param string|array $value
+     * @param string       $boolean
+     * @return \WPKirk\WPBones\Database\QueryBuilder
+     */
+    public function whereIn($column, $value, $boolean = 'and')
+    {
+        $value = is_string($value) ? explode(',', $value) : $value;
+        $operator = 'IN';
+        $this->wheres[] = compact('column', 'operator', 'value', 'boolean');
 
-    [$columns, $values] = $this->getColumnsAndValues($values);
+        return $this;
+    }
 
-    $sql = "INSERT INTO `{$this->table}` " . "($columns) " . 'VALUES ' . "($values)";
+    /**
+     * Add a where NOT IN condition to the query.
+     *
+     * @param string       $column The column name.
+     * @param string|array $value  The values.
+     */
+    public function orWhereNotIn($column, $value)
+    {
+        return $this->whereNotIn($column, $value, 'or');
+    }
 
-    $this->query($sql);
+    /**
+     * Add a where NOT IN condition to the query.
+     *
+     * @param string       $column The column name.
+     * @param array|string $value  The values.
+     */
+    public function whereNotIn($column, $value, $boolean = 'and')
+    {
+        $value = is_string($value) ? explode(',', $value) : $value;
+        $operator = 'NOT IN';
+        $this->wheres[] = compact('column', 'operator', 'value', 'boolean');
 
-    return $this->wpdb->insert_id;
-  }
+        return $this;
+    }
 
-  /**
-   * Return column and value for the query.
-   *
-   * @param array $values
-   * @return array
-   */
-  private function getColumnsAndValues($values): array
-  {
-    $columns = array_keys($values);
-    $columns_string = implode(',', $columns);
-    $values_string = implode(
-      ',',
-      array_map(function ($value) {
-        return "'" . $this->wpdb->_real_escape($value) . "'";
-      }, $values)
-    );
+    /**
+     * Add a where BETWEEN condition to the query.
+     *
+     * @param string       $column The column name.
+     * @param array|string $value  The values.
+     */
+    public function orWhereBetween($column, $value)
+    {
+        return $this->whereBetween($column, $value, 'or');
+    }
 
-    return [$columns_string, $values_string];
-  }
+    /**
+     * Add a where BETWEEN condition to the query.
+     *
+     * @param string       $column The column name.
+     * @param array|string $value  The values.
+     */
+    public function whereBetween($column, $value, $boolean = 'and')
+    {
+        $value = is_string($value) ? explode(',', $value) : $value;
+        $operator = 'BETWEEN';
+        $this->wheres[] = compact('column', 'operator', 'value', 'boolean');
 
-  /**
-   * Update one or more records.
-   *
-   * @param array $values The data to update.
-   */
-  public function update($values)
-  {
-    $set = implode(
-      ',',
-      array_map(function ($key) use ($values) {
-        return "`$key` = " . (is_numeric($values[$key]) ? $values[$key] : "'$values[$key]'");
-      }, array_keys($values))
-    );
+        return $this;
+    }
 
-    $sql = "UPDATE `{$this->table}` " . "SET {$set} " . $this->getWhere();
+    /**
+     * Add a where NOT BETWEEN condition to the query.
+     *
+     * @param string       $column The column name.
+     * @param array|string $value  The values.
+     */
+    public function orWhereNotBetween($column, $value)
+    {
+        return $this->whereNotBetween($column, $value, 'or');
+    }
 
-    return $this->query($sql);
-  }
+    /**
+     * Add a where NOT BETWEEN condition to the query.
+     *
+     * @param string       $column The column name.
+     * @param array|string $value  The values.
+     */
+    public function whereNotBetween($column, $value, $boolean = 'and')
+    {
+        $value = is_string($value) ? explode(',', $value) : $value;
+        $operator = 'NOT BETWEEN';
+        $this->wheres[] = compact('column', 'operator', 'value', 'boolean');
 
-  /*
-     |--------------------------------------------------------------------------
-     | Getters and Setters
-     |--------------------------------------------------------------------------
-     |
-     | Special Getters and Setters for the model.
-     |
+        return $this;
+    }
+
+    /**
+     * Set the offset "limit" clause for the query.
+     */
+    public function offset($value = 0)
+    {
+        $this->offset = max(0, (int) $value);
+
+        return $this;
+    }
+
+    /**
+     * Return a single column's value from the first result of the query.
+     *
+     * @return mixed
+     */
+    public function value($attribute)
+    {
+        return $this->first()->$attribute;
+    }
+
+    /**
+     * Return the count of the records that match the given where conditions.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        $sql =
+        'SELECT COUNT(*) ' .
+        "FROM `{$this->table}`" .
+        $this->getWhere() .
+        $this->getOrderBy() .
+        $this->getLimit() .
+        $this->getOffset();
+
+        return $this->var($sql);
+    }
+
+    /**
+     * Execute a wpdb->get_var() query.
+     *
+     * @return mixed
+     */
+    protected function var ($sql)
+    {
+        return $this->wpdb->get_var($sql);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | wpdb wrapper
+    |--------------------------------------------------------------------------
+    |
+    |
      */
 
-  /**
-   * Truncate the table.
-   */
-  public function truncate(): QueryBuilder
-  {
-    $sql = "TRUNCATE TABLE `{$this->table}`";
-    $this->query($sql);
+    /**
+     * Insert one or more records.
+     *
+     * @param array $values The data to insert.
+     *
+     * @return int|array The inserted id.
+     */
+    public function insert($values)
+    {
+        // here we can get a single or multiple array of values
+        if (count($values) !== count($values, COUNT_RECURSIVE)) {
+            $ids = [];
+            foreach ($values as $value) {
+                $ids[] = $this->insert($value);
+            }
 
-    return $this;
-  }
+            return $ids;
+        }
 
-  /**
-   * Return the primary key.
-   *
-   * @return string
-   */
-  public function getPrimaryKey(): string
-  {
-    return $this->primaryKey;
-  }
+        $columns = array_keys($values);
 
-  /**
-   * Set the primary key.
-   */
-  public function setPrimaryKey($primaryKey)
-  {
-    $this->primaryKey = $primaryKey;
-  }
+        [$columns, $values] = $this->getColumnsAndValues($values);
 
-  /**
-   * Return the table name without the prefix.
-   *
-   * @return string
-   */
-  public function getTable(): string
-  {
-    return $this->table;
-  }
+        $sql = "INSERT INTO `{$this->table}` " . "($columns) " . 'VALUES ' . "($values)";
 
-  /**
-   * Set the table name without the prefix.
-   *
-   * @param string $table The table name without the prefix.
-   */
-  public function setTable($table)
-  {
-    $this->table = $table;
-  }
+        $this->query($sql);
 
-  public function getParentModel()
-  {
-    return $this->parentModel;
-  }
+        return $this->wpdb->insert_id;
+    }
 
-  public function setParentModel($parentModel)
-  {
-    $this->parentModel = $parentModel;
-  }
+    /**
+     * Return column and value for the query.
+     *
+     * @param array $values
+     * @return array
+     */
+    private function getColumnsAndValues($values): array
+    {
+        $columns = array_keys($values);
+        $columns_string = implode(',', $columns);
+        $values_string = implode(
+            ',',
+            array_map(function ($value) {
+                return "'" . $this->wpdb->_real_escape($value) . "'";
+            }, $values)
+        );
+
+        return [$columns_string, $values_string];
+    }
+
+    /**
+     * Update one or more records.
+     *
+     * @param array $values The data to update.
+     */
+    public function update($values)
+    {
+        $set = implode(
+            ',',
+            array_map(function ($key) use ($values) {
+                return "`$key` = " . (is_numeric($values[$key]) ? $values[$key] : "'$values[$key]'");
+            }, array_keys($values))
+        );
+
+        $sql = "UPDATE `{$this->table}` " . "SET {$set} " . $this->getWhere();
+
+        return $this->query($sql);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Getters and Setters
+    |--------------------------------------------------------------------------
+    |
+    | Special Getters and Setters for the model.
+    |
+     */
+
+    /**
+     * Truncate the table.
+     */
+    public function truncate(): QueryBuilder
+    {
+        $sql = "TRUNCATE TABLE `{$this->table}`";
+        $this->query($sql);
+
+        return $this;
+    }
+
+    /**
+     * Return the primary key.
+     *
+     * @return string
+     */
+    public function getPrimaryKey(): string
+    {
+        return $this->primaryKey;
+    }
+
+    /**
+     * Set the primary key.
+     */
+    public function setPrimaryKey($primaryKey)
+    {
+        $this->primaryKey = $primaryKey;
+    }
+
+    /**
+     * Return the table name without the prefix.
+     *
+     * @return string
+     */
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    /**
+     * Set the table name without the prefix.
+     *
+     * @param string $table The table name without the prefix.
+     */
+    public function setTable($table)
+    {
+        $this->table = $table;
+    }
+
+    public function getParentModel()
+    {
+        return $this->parentModel;
+    }
+
+    public function setParentModel($parentModel)
+    {
+        $this->parentModel = $parentModel;
+    }
 }


### PR DESCRIPTION
Hi!
First of all, for context, I'm currently working in a application that needs to query data from WP Multisite and from another system in the same DB. So I did some modifications to the database connector.

# Multisites
To query the WP multisite we need to know if is an site-wide table or a site only table, so based in the [DB Structure for WP Multisite](https://docs.wpvip.com/wordpress-on-vip/multisites/database-structure/) we need to query only these tables without wp specific site prefix (_aka blog_id_):
`blogs,blog_versions,registration_log,signups,site,sitemeta,users,usermeta`

So, for example if we are on Site ID 4, we can query posts in this way:

The Post Model
```
class Post extends Model
{
    protected $usePrefix = true;
    protected $table = "posts";
}
```
This will query the `wp_4_posts` table.

In a site-wide table, we can query on this way

The Class Model
```
class Site extends Model
{
    protected $usePrefix = true;
    protected $table = "site";
}
```
This will query the `wp_site` table.

The function `getTableName` on [`DB.php#115`](https://github.com/bredecl/WPBones/blob/4beefed20d222b081b873fc9d2a0c9f274f1b94d/src/Database/QueryBuilder.php#L630) will detect if is a multisite or site table.

# Raw Queries
I miss the DB:Raw of `Illuminate\Support\Facades\DB`, so I made this _unsecured_ modification (yes, we can secure it a little bit)

I added the function `selectRaw` on [`QueryBuilder.php#630`](https://github.com/bredecl/WPBones/blob/4beefed20d222b081b873fc9d2a0c9f274f1b94d/src/Database/QueryBuilder.php#L630) so we can query raw code, for example
```
Cities::selectRaw("concat(crm_cities.name,', ',crm_states.name) as name, crm_cities.id")->get();
```

# Join Queries

Now we can make join queries with the function `join` on [`QueryBuilder.php#301`](https://github.com/bredecl/WPBones/blob/4beefed20d222b081b873fc9d2a0c9f274f1b94d/src/Database/QueryBuilder.php#L301)

```
City::join("crm_states","crm_states.id","=","state_id")->get();
```

Also you can mix it with raw queries, like this:
```
City::join("crm_states","crm_states.id","=","state_id")->selectRaw("concat(crm_cities.name,', ',crm_states.name) as name, crm_cities.id")->get();
```

Hope this works, I tried on several test and works fine, but I hope this don't mess the currently code.
Happy new year :)