### PR TITLE
Improve support for CPT and CTT

### DIFF
--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -573,11 +573,12 @@ namespace Bones\Traits {
      * @param string $str The question to ask
      * @param string|null $default The default value
      */
-    protected function ask(string $str, ?string $default = ''): string
+    protected function ask(string $str, ?string $default = '',?string $example = ''): string
     {
 
       $str = WPBONES_COLOR_GREEN .
         "❓ $str" .
+        (empty($example) ? '' : " ie: {$example}") .
         (empty($default) ? ': ' : " (default: {$default}): ") .
         WPBONES_COLOR_RESET;
 
@@ -2591,28 +2592,26 @@ namespace Bones {
       }
 
       // ask className if empty
-      $className = $this->askClassNameIfEmpty($className);
-
-      $filename = sprintf('%s.php', $className);
+      $className  = $this->askClassNameIfEmpty($className);
+      $filename   = sprintf('%s.php', $className);
       // current plugin name and namespace
       [$pluginName, $namespace] = $this->getPluginNameAndNamespace();
-      $className = ucfirst($this->sanitize($className));
-      $name = ($className);
-      $plural = ucfirst($this->simplePluralize($className));
-      $slug = $this->slugify($namespace,$plural);
-      
-      $id = $this->ask('Enter a ID', $slug);
-      $name = $this->ask('Enter the name',$name);
-      $plural = $this->ask('Enter the plural name',$plural);
+      $className  = ucfirst($this->sanitize($className));
+      $name       = ($className);
+      $plural     = ucfirst($this->simplePluralize($className));
+      $slug       = $this->slugify($namespace,$plural);
+      $id         = $this->ask('Enter a ID', $slug);
+      $name       = $this->ask('Enter the name',$name);
+      $plural     = $this->ask('Enter the plural name',$plural);
 
       $showInRest = true;
       $showInRest = $this->askYesNo('Show in Rest?',$showInRest);
 
-      $showUI = true;
-      $showUI = $this->askYesNo('Show in admin sidebar?',$showUI);
+      $showUI     = true;
+      $showUI     = $this->askYesNo('Show in admin sidebar?',$showUI);
 
-      $supports = 'title, editor, thumbnail, excerpt';
-      $supports = $this->ask('Features available for the CPT',$supports);
+      $supports   = 'title, editor, thumbnail, excerpt';
+      $supports   = $this->ask('Features available for the CPT',$supports);
       $itemsSupport  = $this->stringToArray($supports);
   
       if (empty($id)) {
@@ -2621,14 +2620,14 @@ namespace Bones {
 
       // stubbing
       $content = $this->prepareStub('cpt', [
-        '{Namespace}' => $namespace,
-        '{ClassName}' => $className,
-        '{ID}' => $id,
-        '{Name}' => $name,
-        '{Plural}' => $plural,
-        '{ShowInRest}' => $showInRest,
-        '{showUI}' => $showUI,
-        '{Supports}' => "'".join("','",$itemsSupport)."'",
+        '{Namespace}'   => $namespace,
+        '{ClassName}'   => $className,
+        '{ID}'          => $id,
+        '{Name}'        => $name,
+        '{Plural}'      => $plural,
+        '{ShowInRest}'  => $showInRest,
+        '{showUI}'      => $showUI,
+        '{Supports}'    => "'".join("','",$itemsSupport)."'",
       ]);
 
       // Create the folder if it doesn't exist
@@ -2641,7 +2640,7 @@ namespace Bones {
       $this->line(" Created plugin/CustomPostTypes/{$filename}");
 
       $this->info(
-        "Remember to add {$namespace}\CustomPostTypes\\{$className} in the config/plugin.php array in the 'custom_post_types' key."
+        "Remember to add \\{$namespace}\CustomPostTypes\\{$className} in the config/plugin.php array in the 'custom_post_types' key."
       );
     }
     private function stringToArray($content){
@@ -2656,7 +2655,7 @@ namespace Bones {
     private function slugify($namespace,$name,$remove=0){
 
       $subNamespace = substr($namespace,0,20-$remove-strlen($name)-1);
-      $slug = strtolower($subNamespace."_".str_replace('-', '_', $name));
+      $slug = strtolower($subNamespace.(empty($namespace)?"":"_").str_replace('-', '_', $name));
       $length = strlen($slug);
       if($length>20){
         return $this->slugify($namespace,$name,$length-20);
@@ -2840,25 +2839,30 @@ namespace Bones {
       }
 
       // ask className if empty
-      $className = $this->askClassNameIfEmpty($className);
-
-      $filename = sprintf('%s.php', $className);
+      $className  = $this->askClassNameIfEmpty($className);
+      $filename   = sprintf('%s.php', $className);
 
       // current plugin name and namespace
-      $namespace = $this->getNamespace();
-
-      $slug = $this->getPluginId();
-
-      $id = $this->ask('Enter a ID', $slug);
-      $name = $this->ask('Enter the name');
-      $plural = $this->ask('Enter the plural name');
-
+      $namespace  = $this->getNamespace();
+      // current plugin name and namespace
+      $className  = ucfirst($this->sanitize($className));
+      $name       = $className;
+      $plural     = ucfirst($this->simplePluralize($className));
+      $slug       = $this->slugify("",$plural);
+      $id         = $this->ask('Enter a ID', $slug);
+      $name       = $this->ask('Enter the name',$name);
+      $plural     = $this->ask('Enter the plural name',$plural);
+      $showInRest = true;
+      $showInRest = $this->askYesNo('Show in Rest?',$showInRest);
+       
       $this->line(
         'The object type below refers to the id of your previous Custom Post Type'
       );
-
-      $objectType = $this->ask('Enter the object type to bound');
-
+      $objectType ="post";
+      $example ="post, your_custom_post_type, etc";
+      $objectType = $this->ask('Enter the object type to bound',$objectType,$example);
+      $objectType  = $this->stringToArray($objectType);
+      
       if (empty($id)) {
         $id = $slug;
       }
@@ -2869,8 +2873,9 @@ namespace Bones {
         '{ClassName}' => $className,
         '{ID}' => $id,
         '{Name}' => $name,
+        '{ShowInRest}'  => $showInRest,
         '{Plural}' => $plural,
-        '{ObjectType}' => $objectType,
+        '{ObjectType}' =>  "'".join("','",$objectType)."'",
       ]);
 
       // Create the folder if it doesn't exist
@@ -2883,7 +2888,7 @@ namespace Bones {
       $this->line(" Created plugin/CustomTaxonomyTypes/{$filename}");
 
       $this->info(
-        "Remember to add {$className} in the config/plugin.php array in the 'custom_taxonomy_types' key."
+        "Remember to add \\{$namespace}\CustomTaxonomyTypes\\{$className} in the config/plugin.php array in the 'custom_taxonomy_types' key."
       );
     }
 

--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -589,6 +589,33 @@ namespace Bones\Traits {
 
       return $line ?: $default;
     }
+    /**
+     * Get input from console
+     *
+     * @param string $str The question to ask
+     * @param string|null $default The default value
+     */
+    protected function askYesNo(string $str, bool $default = true): string
+    {
+
+      $str = WPBONES_COLOR_GREEN .
+        "❓ $str (".($default?"Y/n":"y/N").")" .
+         " (default: ".($default?"Yes":"No")."): " .
+        WPBONES_COLOR_RESET;
+
+      // Use readline to get the user input
+      $line = readline($str);
+
+      // Trim the input to remove extra spaces or newlines
+      $line = strtoupper(trim($line));
+      if($line=="Y"||$line=="YES"){
+        return "true";
+      }else if($line=="N"||$line=="NO"){
+        return "false";
+      }else{
+          return $default?"true":"false";
+      }
+    }
   }
 }
 
@@ -2508,6 +2535,47 @@ namespace Bones {
         $this->line(' Created plugin/Console/Kernel.php');
       }
     }
+    protected function simplePluralize($word) {
+      $strLength = strlen($word);
+      $last = strtolower($word[$strLength - 1]);
+      $secondLast = $strLength > 1 ? strtolower($word[$strLength - 2]) : '';
+  
+      // Special cases (irregulars)
+      $irregular = [
+          'child' => 'children',
+          'man' => 'men',
+          'woman' => 'women',
+          'tooth' => 'teeth',
+          'foot' => 'feet',
+          'mouse' => 'mice',
+          'goose' => 'geese',
+          'person' => 'people',
+      ];
+  
+      if (array_key_exists(strtolower($word), $irregular)) {
+          return $irregular[strtolower($word)];
+      }
+  
+      // common words
+      if ($last === 's' || $last === 'x' || $last === 'z' || ($secondLast . $last) === 'ch' || ($secondLast . $last) === 'sh') {
+          return $word . 'es';
+      }
+  
+      if ($last === 'y' && !in_array($secondLast, ['a', 'e', 'i', 'o', 'u'])) {
+          return substr($word, 0, $strLength - 1) . 'ies';
+      }
+  
+      if ($last === 'f' || ($secondLast . $last) === 'fe') {
+          $base = substr($word, 0, $strLength - ($last === 'f' ? 1 : 2));
+          return $base . 'ves';
+      }
+  
+      if ($last === 'o' && in_array($secondLast, ['a', 'e', 'i', 'o', 'u']) === false) {
+          return $word . 'es';
+      }
+  
+      return $word . 's';
+  }
 
     /**
      * Create a Custom Post Type controller
@@ -2526,16 +2594,27 @@ namespace Bones {
       $className = $this->askClassNameIfEmpty($className);
 
       $filename = sprintf('%s.php', $className);
-
       // current plugin name and namespace
       [$pluginName, $namespace] = $this->getPluginNameAndNamespace();
-
-      $slug = str_replace('-', '_', $this->sanitize($pluginName));
-
+      $className = ucfirst($this->sanitize($className));
+      $name = ($className);
+      $plural = ucfirst($this->simplePluralize($className));
+      $slug = $this->slugify($namespace,$plural);
+      
       $id = $this->ask('Enter a ID', $slug);
-      $name = $this->ask('Enter the name');
-      $plural = $this->ask('Enter the plural name');
+      $name = $this->ask('Enter the name',$name);
+      $plural = $this->ask('Enter the plural name',$plural);
 
+      $showInRest = true;
+      $showInRest = $this->askYesNo('Show in Rest?',$showInRest);
+
+      $showUI = true;
+      $showUI = $this->askYesNo('Show in admin sidebar?',$showUI);
+
+      $supports = 'title, editor, thumbnail, excerpt';
+      $supports = $this->ask('Features available for the CPT',$supports);
+      $itemsSupport  = $this->stringToArray($supports);
+  
       if (empty($id)) {
         $id = $slug;
       }
@@ -2547,6 +2626,9 @@ namespace Bones {
         '{ID}' => $id,
         '{Name}' => $name,
         '{Plural}' => $plural,
+        '{ShowInRest}' => $showInRest,
+        '{showUI}' => $showUI,
+        '{Supports}' => "'".join("','",$itemsSupport)."'",
       ]);
 
       // Create the folder if it doesn't exist
@@ -2559,8 +2641,27 @@ namespace Bones {
       $this->line(" Created plugin/CustomPostTypes/{$filename}");
 
       $this->info(
-        "Remember to add {$className} in the config/plugin.php array in the 'custom_post_types' key."
+        "Remember to add {$namespace}\CustomPostTypes\\{$className} in the config/plugin.php array in the 'custom_post_types' key."
       );
+    }
+    private function stringToArray($content){
+      $itemsSupport=[]    ;
+      foreach(explode(",",$content) as $item)
+      {
+        if(!empty($item))
+          $itemsSupport[]=$item;
+      }
+      return $itemsSupport;
+    }
+    private function slugify($namespace,$name,$remove=0){
+
+      $subNamespace = substr($namespace,0,20-$remove-strlen($name)-1);
+      $slug = strtolower($subNamespace."_".str_replace('-', '_', $name));
+      $length = strlen($slug);
+      if($length>20){
+        return $this->slugify($namespace,$name,$length-20);
+      }
+      return $slug;
     }
 
     /**

--- a/src/Console/stubs/cpt.stub
+++ b/src/Console/stubs/cpt.stub
@@ -11,9 +11,13 @@ use {Namespace}\WPBones\Foundation\WordPressCustomPostTypeServiceProvider as Ser
 class {ClassName} extends ServiceProvider
 {
 
-  protected $id     = '{ID}';
-  protected $name   = '{Name}';
-  protected $plural = '{Plural}';
+  protected $id         = '{ID}';
+  protected $name       = '{Name}';
+  protected $plural     = '{Plural}';
+  protected $showInRest = {ShowInRest};
+  protected $showUI     = {showUI};
+  protected $supports   = [{Supports}];
+  protected $menuIcon   = "dashicons-admin-post";
 
   /**
    * You may override this method in order to register your own actions and filters.

--- a/src/Console/stubs/ctt.stub
+++ b/src/Console/stubs/ctt.stub
@@ -14,7 +14,8 @@ class {ClassName} extends ServiceProvider
   protected $id         = '{ID}';
   protected $name       = '{Name}';
   protected $plural     = '{Plural}';
-  protected $objectType = '{ObjectType}';
+  protected $showInRest = {ShowInRest};
+  protected $objectType = [{ObjectType}];
 
   /**
    * You may override this method in order to register your own actions and filters.

--- a/src/Foundation/WordPressCustomPostTypeServiceProvider.php
+++ b/src/Foundation/WordPressCustomPostTypeServiceProvider.php
@@ -422,6 +422,7 @@ abstract class WordPressCustomPostTypeServiceProvider extends ServiceProvider
     $this->boot();
 
     // Register custom post type
+
     register_post_type($this->id, $this->optionalArgs());
 
     $this->initHooks();
@@ -619,6 +620,7 @@ abstract class WordPressCustomPostTypeServiceProvider extends ServiceProvider
 
       // Hook save post
       add_action('save_post_' . $this->id, [$this, 'save_post'], 10, 2);
+      add_action('trash_' . $this->id, [$this, 'trash_post'], 10, 3);
 
       // Manage columns @since 1.9.0
       add_filter("manage_{$this->id}_posts_columns", [$this, '_manage_posts_columns']);
@@ -915,6 +917,18 @@ abstract class WordPressCustomPostTypeServiceProvider extends ServiceProvider
     if (Request::isVerb('post')) {
       $this->_update($post_id, $post);
     }
+  }
+
+  /**
+   * Override this method when your post was trashed.
+   * This method is called by hook action trashed_{post_type}`
+   *
+   * @param int|string $post_id Post ID
+   * @param object     $post    Optional. Post object
+   *
+   */
+  public function trash_post($post_id, $post, $old_status ){
+
   }
 
   /**


### PR DESCRIPTION
Hi 
I made some improvements for the bones cli and content

- Added support to ask yes or no and returns a string to be used directly in stubs
- Better code for CPT, so now generates automatically the default name, plural, slug based on name
- Added a function to avoid create a post_type name larger than 20 characters (as described here: https://developer.wordpress.org/reference/functions/register_post_type/ )
- Added support to set showInRest and showUI directly supports in CPT
- Added a default icon for the stub of CPT, so we avoid the empty space
- fix to avoid loop the menu -> items when is empty
- Added support to show an example on ask method
- Added support to pre-fill the data on CTT
- Allow multiple Post Type support to CTT
- Added support to set showui by default on CTT
- Added support to manage CPT trash event.