### PR TITLE
🐛 fix: expose $this->plugin in Console commands

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -78,7 +78,7 @@ abstract class Command
    *
    * @var bool
    */
-  protected bool $pluginBootstrapLoaded = false;
+  protected bool $pluginBootstrapExecuted = false;
 
   /**
    *
@@ -351,8 +351,8 @@ abstract class Command
        * Load this plugin env
        * --------------------------------------------------------------------------
        */
-      if (!$this->pluginBootstrapLoaded && file_exists($currentDir . '/bootstrap/plugin.php')) {
-        $this->pluginBootstrapLoaded = true;
+      if (!$this->pluginBootstrapExecuted && file_exists($currentDir . '/bootstrap/plugin.php')) {
+        $this->pluginBootstrapExecuted = true;
         $this->setPluginAttribute(require $currentDir . '/bootstrap/plugin.php');
       }
     } catch (\Exception $e) {

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -293,17 +293,14 @@ abstract class Command
    *
    * @param mixed $value
    */
-  public function setPluginAttribute($value): bool
+  public function setPluginAttribute($value): void
   {
     if (is_object($value) || is_null($value)) {
       $this->plugin = $value;
-
-      return true;
+      return;
     }
 
     $this->warning('Invalid plugin instance returned from bootstrap/plugin.php');
-
-    return false;
   }
 
   /**
@@ -355,7 +352,8 @@ abstract class Command
        * --------------------------------------------------------------------------
        */
       if (!$this->pluginBootstrapLoaded && file_exists($currentDir . '/bootstrap/plugin.php')) {
-        $this->pluginBootstrapLoaded = $this->setPluginAttribute(require $currentDir . '/bootstrap/plugin.php');
+        $this->pluginBootstrapLoaded = true;
+        $this->setPluginAttribute(require $currentDir . '/bootstrap/plugin.php');
       }
     } catch (\Exception $e) {
       $this->error("Error! Can't load the plugin env (" . $e->getMessage() . ')');

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -74,6 +74,13 @@ abstract class Command
   protected $plugin = null;
 
   /**
+   * Whether bootstrap/plugin.php has already been executed.
+   *
+   * @var bool
+   */
+  protected bool $pluginBootstrapLoaded = false;
+
+  /**
    *
    */
   public function __construct()
@@ -288,7 +295,9 @@ abstract class Command
    */
   public function setPluginAttribute($value): void
   {
-    $this->plugin = $value;
+    if (is_object($value) || is_null($value)) {
+      $this->plugin = $value;
+    }
   }
 
   /**
@@ -339,8 +348,9 @@ abstract class Command
        * Load this plugin env
        * --------------------------------------------------------------------------
        */
-      if (file_exists($currentDir . '/bootstrap/plugin.php')) {
-        $this->plugin = require $currentDir . '/bootstrap/plugin.php';
+      if (!$this->pluginBootstrapLoaded && file_exists($currentDir . '/bootstrap/plugin.php')) {
+        $this->setPluginAttribute(require $currentDir . '/bootstrap/plugin.php');
+        $this->pluginBootstrapLoaded = true;
       }
     } catch (\Exception $e) {
       $this->error("Error! Can't load the plugin env (" . $e->getMessage() . ')');

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -303,6 +303,7 @@ abstract class Command
     $this->warning(
       'Invalid plugin instance returned from bootstrap/plugin.php; expected object or null, got ' . get_debug_type($value)
     );
+    $this->plugin = null;
   }
 
   /**

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -301,7 +301,7 @@ abstract class Command
     }
 
     $this->warning(
-      'Invalid plugin instance returned from bootstrap/plugin.php; expected object or null, got ' . get_debug_type($value)
+      'Invalid plugin instance; expected object or null, got ' . get_debug_type($value)
     );
     $this->plugin = null;
   }

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -293,11 +293,17 @@ abstract class Command
    *
    * @param mixed $value
    */
-  public function setPluginAttribute($value): void
+  public function setPluginAttribute($value): bool
   {
     if (is_object($value) || is_null($value)) {
       $this->plugin = $value;
+
+      return true;
     }
+
+    $this->warning('Invalid plugin instance returned from bootstrap/plugin.php');
+
+    return false;
   }
 
   /**
@@ -349,8 +355,7 @@ abstract class Command
        * --------------------------------------------------------------------------
        */
       if (!$this->pluginBootstrapLoaded && file_exists($currentDir . '/bootstrap/plugin.php')) {
-        $this->setPluginAttribute(require $currentDir . '/bootstrap/plugin.php');
-        $this->pluginBootstrapLoaded = true;
+        $this->pluginBootstrapLoaded = $this->setPluginAttribute(require $currentDir . '/bootstrap/plugin.php');
       }
     } catch (\Exception $e) {
       $this->error("Error! Can't load the plugin env (" . $e->getMessage() . ')');

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -67,6 +67,13 @@ abstract class Command
   protected $argv = [];
 
   /**
+   * The plugin instance, available after calling loadWordPress().
+   *
+   * @var mixed
+   */
+  protected $plugin = null;
+
+  /**
    *
    */
   public function __construct()
@@ -275,15 +282,27 @@ abstract class Command
   }
 
   /**
+   * Set the plugin instance (injected by the Kernel or loadWordPress).
+   *
+   * @param mixed $value
+   */
+  public function setPluginAttribute($value): void
+  {
+    $this->plugin = $value;
+  }
+
+  /**
    * Load WordPress environment.
    *
    * @return void
    */
   protected function loadWordPress()
   {
+    // Plugin root is the working directory when running `php bones`
+    $currentDir = $_SERVER['PWD'] ?? getcwd();
+
     try {
       // We have to load the WordPress environment.
-      $currentDir = $_SERVER['PWD'] ?? __DIR__;
       $wpLoadPath = dirname(dirname(dirname($currentDir))) . '/wp-load.php';
 
       if (!file_exists($wpLoadPath)) {
@@ -306,8 +325,8 @@ abstract class Command
        * need to use it! Requiring it here means we don't have to load classes
        * manually. Feels great to relax.
        */
-      if (file_exists(__DIR__ . '/vendor/autoload.php')) {
-        require __DIR__ . '/vendor/autoload.php';
+      if (file_exists($currentDir . '/vendor/autoload.php')) {
+        require $currentDir . '/vendor/autoload.php';
       }
     } catch (\Exception $e) {
       $this->error("Error! Can't load Composer autoload (" . $e->getMessage() . ')');
@@ -320,8 +339,8 @@ abstract class Command
        * Load this plugin env
        * --------------------------------------------------------------------------
        */
-      if (file_exists(__DIR__ . '/bootstrap/plugin.php')) {
-        require_once __DIR__ . '/bootstrap/plugin.php';
+      if (file_exists($currentDir . '/bootstrap/plugin.php')) {
+        $this->plugin = require $currentDir . '/bootstrap/plugin.php';
       }
     } catch (\Exception $e) {
       $this->error("Error! Can't load the plugin env (" . $e->getMessage() . ')');

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -352,8 +352,9 @@ abstract class Command
        * --------------------------------------------------------------------------
        */
       if (!$this->pluginBootstrapExecuted && file_exists($currentDir . '/bootstrap/plugin.php')) {
+        $plugin = require $currentDir . '/bootstrap/plugin.php';
         $this->pluginBootstrapExecuted = true;
-        $this->setPluginAttribute(require $currentDir . '/bootstrap/plugin.php');
+        $this->setPluginAttribute($plugin);
       }
     } catch (\Exception $e) {
       $this->error("Error! Can't load the plugin env (" . $e->getMessage() . ')');

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -300,7 +300,7 @@ abstract class Command
       return;
     }
 
-    $this->warning('Invalid plugin instance returned from bootstrap/plugin.php');
+    $this->warning('Invalid plugin instance returned from bootstrap/plugin.php; expected object or null');
   }
 
   /**

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -300,7 +300,9 @@ abstract class Command
       return;
     }
 
-    $this->warning('Invalid plugin instance returned from bootstrap/plugin.php; expected object or null');
+    $this->warning(
+      'Invalid plugin instance returned from bootstrap/plugin.php; expected object or null, got ' . get_debug_type($value)
+    );
   }
 
   /**

--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -693,8 +693,8 @@ namespace Bones\Traits {
          * --------------------------------------------------------------------------
          */
         if (!$this->pluginBootstrapExecuted && file_exists(__DIR__ . '/bootstrap/plugin.php')) {
-          $this->pluginBootstrapExecuted = true;
           $plugin = require __DIR__ . '/bootstrap/plugin.php';
+          $this->pluginBootstrapExecuted = true;
           if (is_object($plugin) || is_null($plugin)) {
             $this->plugin = $plugin;
           } else {

--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -698,7 +698,10 @@ namespace Bones\Traits {
           if (is_object($plugin) || is_null($plugin)) {
             $this->plugin = $plugin;
           } else {
-            $this->warning('Invalid plugin instance returned from bootstrap/plugin.php; expected object or null');
+            $this->warning(
+              'Invalid plugin instance returned from bootstrap/plugin.php; expected object or null, got ' .
+                get_debug_type($plugin)
+            );
           }
         }
       } catch (Exception $e) {

--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -698,7 +698,7 @@ namespace Bones\Traits {
           if (is_object($plugin) || is_null($plugin)) {
             $this->plugin = $plugin;
           } else {
-            $this->warning('Invalid plugin instance returned from bootstrap/plugin.php');
+            $this->warning('Invalid plugin instance returned from bootstrap/plugin.php; expected object or null');
           }
         }
       } catch (Exception $e) {

--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -694,8 +694,12 @@ namespace Bones\Traits {
          */
         if (!$this->pluginBootstrapLoaded && file_exists(__DIR__ . '/bootstrap/plugin.php')) {
           $plugin = require __DIR__ . '/bootstrap/plugin.php';
-          $this->plugin = is_object($plugin) ? $plugin : null;
-          $this->pluginBootstrapLoaded = true;
+          if (is_object($plugin) || is_null($plugin)) {
+            $this->plugin = $plugin;
+            $this->pluginBootstrapLoaded = true;
+          } else {
+            $this->warning('Invalid plugin instance returned from bootstrap/plugin.php');
+          }
         }
       } catch (Exception $e) {
         $this->error("Error! Can't load the plugin env (" . $e->getMessage() . ')');
@@ -3179,4 +3183,3 @@ namespace Bones {
 
   BonesCommandLine::run();
 }
-

--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -618,6 +618,9 @@ namespace Bones\Traits {
     // Plugin instance loaded from bootstrap/plugin.php
     protected $plugin = null;
 
+    // Whether bootstrap/plugin.php has already been executed.
+    protected bool $pluginBootstrapLoaded = false;
+
     /* Protected version of the do_action function */
     protected function do_action(...$args)
     {
@@ -689,8 +692,10 @@ namespace Bones\Traits {
          * Load this plugin env
          * --------------------------------------------------------------------------
          */
-        if (file_exists(__DIR__ . '/bootstrap/plugin.php')) {
-          $this->plugin = require __DIR__ . '/bootstrap/plugin.php';
+        if (!$this->pluginBootstrapLoaded && file_exists(__DIR__ . '/bootstrap/plugin.php')) {
+          $plugin = require __DIR__ . '/bootstrap/plugin.php';
+          $this->plugin = is_object($plugin) ? $plugin : null;
+          $this->pluginBootstrapLoaded = true;
         }
       } catch (Exception $e) {
         $this->error("Error! Can't load the plugin env (" . $e->getMessage() . ')');

--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -619,7 +619,7 @@ namespace Bones\Traits {
     protected $plugin = null;
 
     // Whether bootstrap/plugin.php has already been executed.
-    protected bool $pluginBootstrapLoaded = false;
+    protected bool $pluginBootstrapExecuted = false;
 
     /* Protected version of the do_action function */
     protected function do_action(...$args)
@@ -692,8 +692,8 @@ namespace Bones\Traits {
          * Load this plugin env
          * --------------------------------------------------------------------------
          */
-        if (!$this->pluginBootstrapLoaded && file_exists(__DIR__ . '/bootstrap/plugin.php')) {
-          $this->pluginBootstrapLoaded = true;
+        if (!$this->pluginBootstrapExecuted && file_exists(__DIR__ . '/bootstrap/plugin.php')) {
+          $this->pluginBootstrapExecuted = true;
           $plugin = require __DIR__ . '/bootstrap/plugin.php';
           if (is_object($plugin) || is_null($plugin)) {
             $this->plugin = $plugin;

--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -615,6 +615,9 @@ namespace Bones\Traits {
     // WordPress loaded flag
     protected $wpLoaded = false;
 
+    // Plugin instance loaded from bootstrap/plugin.php
+    protected $plugin = null;
+
     /* Protected version of the do_action function */
     protected function do_action(...$args)
     {
@@ -687,7 +690,7 @@ namespace Bones\Traits {
          * --------------------------------------------------------------------------
          */
         if (file_exists(__DIR__ . '/bootstrap/plugin.php')) {
-          require_once __DIR__ . '/bootstrap/plugin.php';
+          $this->plugin = require __DIR__ . '/bootstrap/plugin.php';
         }
       } catch (Exception $e) {
         $this->error("Error! Can't load the plugin env (" . $e->getMessage() . ')');
@@ -1425,6 +1428,9 @@ namespace Bones {
         $extended = false;
 
         if ($this->kernel) {
+          if (!is_null($this->plugin)) {
+            $this->kernel->setPlugin($this->plugin);
+          }
           $extended = $this->kernel->handle($this->arguments());
         }
 

--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -693,10 +693,10 @@ namespace Bones\Traits {
          * --------------------------------------------------------------------------
          */
         if (!$this->pluginBootstrapLoaded && file_exists(__DIR__ . '/bootstrap/plugin.php')) {
+          $this->pluginBootstrapLoaded = true;
           $plugin = require __DIR__ . '/bootstrap/plugin.php';
           if (is_object($plugin) || is_null($plugin)) {
             $this->plugin = $plugin;
-            $this->pluginBootstrapLoaded = true;
           } else {
             $this->warning('Invalid plugin instance returned from bootstrap/plugin.php');
           }

--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -702,6 +702,7 @@ namespace Bones\Traits {
               'Invalid plugin instance returned from bootstrap/plugin.php; expected object or null, got ' .
                 get_debug_type($plugin)
             );
+            $this->plugin = null;
           }
         }
       } catch (Exception $e) {

--- a/src/Foundation/Console/Kernel.php
+++ b/src/Foundation/Console/Kernel.php
@@ -21,6 +21,20 @@ class Kernel
     return !empty($this->instances);
   }
 
+  /**
+   * Inject the plugin instance into all registered command instances.
+   *
+   * @param mixed $plugin
+   */
+  public function setPlugin($plugin): void
+  {
+    foreach ($this->instances as $commands) {
+      foreach ($commands as $command) {
+        $command->plugin = $plugin;
+      }
+    }
+  }
+
   public function handle($argv)
   {
     // wpkirk:sample


### PR DESCRIPTION
- Add protected $plugin property and setPluginAttribute() setter to Command
- Fix loadWordPress() to use $currentDir (plugin root via $_SERVER['PWD']) instead of __DIR__ for vendor/bootstrap paths, which was resolving to the wrong directory inside the vendor tree
- Capture the return value of bootstrap/plugin.php so $this->plugin is populated after calling loadWordPress()
- Add Kernel::setPlugin() to propagate the plugin instance to all registered command instances
- Store plugin in BonesCommandLine and pass it to the kernel before dispatching custom commands