### PR TITLE
🐛 fix: prevent str_repeat ValueError in Kernel::displayHelp()

### DIFF
--- a/src/Foundation/Console/Kernel.php
+++ b/src/Foundation/Console/Kernel.php
@@ -50,8 +50,7 @@ class Kernel
       }
 
       foreach ($commands as $key => $command) {
-        $name = $command->command;
-        $name .= str_repeat(' ', 23 - strlen($name));
+        $name = str_pad($command->command, 23);
         $description = $command->description;
         $this->line(" {$name} {$description}");
       }


### PR DESCRIPTION
 ## Summary
  - `Kernel::displayHelp()` computed padding via `str_repeat(' ', 23 - strlen($name))`, which throws `ValueError` on PHP
   8+ when a command name is 24+ characters long, crashing `php bones --help`.
  - Replaced with `str_pad($command->command, 23)`, which yields identical output for short names and safely leaves
  longer names untouched (the existing space separator in the output line still delimits name from description).

  ## Repro (before fix)
  Any plugin registering a command whose `$command` string is ≥ 24 chars triggers:
  Fatal error: Uncaught ValueError: str_repeat(): Argument #2 ($times) must be greater than or equal to 0
    in src/Foundation/Console/Kernel.php:68

  ## Test plan
  - [ ] `php bones --help` runs without error on a plugin with a short command name (≤23 chars) — output unchanged.
  - [ ] `php bones --help` runs without error on a plugin with a long command name (≥24 chars) — no fatal, name column
  is not padded but description is still readable.
  - [ ] No regressions in `php bones <command>` dispatch (unrelated code path, sanity check).