### PR TITLE
🙈 chore(gitignore): fix typo nodes_modules -> node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/nodes_modules
+/node_modules
 release.sh
 vendor/
 .idea/


### PR DESCRIPTION
## Summary

Pre-existing typo in `.gitignore`: `/nodes_modules` should be `/node_modules`. As written, the rule matches a directory that does not exist, leaving actual `node_modules/` folders effectively unignored.

## Change

```diff
-/nodes_modules
+/node_modules
```

## Test plan

- [ ] `git check-ignore -v node_modules` resolves against the fixed rule.