### PR TITLE
🚀 chore(release): bump to v1.11.1

### DIFF
--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -708,7 +708,7 @@ namespace Bones {
   define('WPBONES_MINIMAL_PHP_VERSION', '7.4');
 
   /* MARK: The WP Bones command line version. */
-  define('WPBONES_COMMAND_LINE_VERSION', '1.11.0');
+  define('WPBONES_COMMAND_LINE_VERSION', '1.11.1');
 
   use Bones\SemVer\Exceptions\InvalidVersionException;
   use Bones\SemVer\Version;


### PR DESCRIPTION
## Release v1.11.1

Patch release bundling three bugfixes / chore merged since v1.11.0.

### Bug Fixes

- #68 — Skip `loadKernel()` for `rename` command on bootstrap. Fixes fatal `Class not found` when running `composer update` on a plugin whose namespace was previously renamed.
- #69 — Prevent `str_repeat()` ValueError in `Kernel::displayHelp()` when a custom command name is 24+ characters. `php bones --help` no longer crashes.

### Chore

- #70 — Fix typo in `.gitignore`: `/nodes_modules` → `/node_modules`.

### Bump

Updates `WPBONES_COMMAND_LINE_VERSION` from `1.11.0` to `1.11.1` in `src/Console/bin/bones`.