### PR TITLE
🐛 fix(view): route inline/localize scripts to admin apps bucket

### DIFF
--- a/src/View/Assets/AssetEnqueuer.php
+++ b/src/View/Assets/AssetEnqueuer.php
@@ -60,12 +60,10 @@ abstract class AssetEnqueuer
    */
   public function enqueueScripts(): void
   {
-    if (!$this->assetManager->hasScripts()) {
-      return;
-    }
-
-    foreach ($this->assetManager->getScripts() as $script) {
-      $this->enqueueScript($script);
+    if ($this->assetManager->hasScripts()) {
+      foreach ($this->assetManager->getScripts() as $script) {
+        $this->enqueueScript($script);
+      }
     }
 
     $this->enqueueLocalizeScripts();
@@ -79,12 +77,10 @@ abstract class AssetEnqueuer
    */
   public function enqueueStyles(): void
   {
-    if (!$this->assetManager->hasStyles()) {
-      return;
-    }
-
-    foreach ($this->assetManager->getStyles() as $style) {
-      $this->enqueueStyle($style);
+    if ($this->assetManager->hasStyles()) {
+      foreach ($this->assetManager->getStyles() as $style) {
+        $this->enqueueStyle($style);
+      }
     }
 
     $this->enqueueInlineStyles();

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -301,7 +301,11 @@ class View
   public function withLocalizeScript($handle, $name, $l10n): View
   {
     if (is_admin()) {
-      $this->adminAssets->addLocalizeScript($handle, $name, $l10n);
+      if ($this->adminAppsAssetsHasHandle($handle)) {
+        $this->adminAppsAssets->addLocalizeScript($handle, $name, $l10n);
+      } else {
+        $this->adminAssets->addLocalizeScript($handle, $name, $l10n);
+      }
     } else {
       $this->frontendAssets->addLocalizeScript($handle, $name, $l10n);
     }
@@ -339,12 +343,29 @@ class View
   public function withInlineScript($name, $data, $position = 'after'): View
   {
     if (is_admin()) {
-      $this->adminAssets->addInlineScript($name, $data, $position);
+      // Route to the asset manager that owns the handle so wp_add_inline_script()
+      // runs after the matching wp_enqueue_script() — otherwise the handle is
+      // unknown and WordPress silently drops the inline script.
+      if ($this->adminAppsAssetsHasHandle($name)) {
+        $this->adminAppsAssets->addInlineScript($name, $data, $position);
+      } else {
+        $this->adminAssets->addInlineScript($name, $data, $position);
+      }
     } else {
       $this->frontendAssets->addInlineScript($name, $data, $position);
     }
 
     return $this;
+  }
+
+  protected function adminAppsAssetsHasHandle(string $name): bool
+  {
+    foreach ($this->adminAppsAssets->getScripts() as $script) {
+      if (($script['name'] ?? null) === $name) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
## Summary
- `withInlineScript()` and `withLocalizeScript()` now route to `adminAppsAssets` when the target handle was registered via `withAdminAppsScript()`. Before, they always hit `adminAssets`, so `wp_add_inline_script()` fired **before** the apps-enqueuer registered the script — WordPress silently dropped it.
- Removed the early-exit in `AssetEnqueuer::enqueueScripts()` / `enqueueStyles()`: inline and localize data now run even when only inline payloads are present.

## Why it matters
Any controller pattern like this was broken in v2.0.0:

\`\`\`php
->withAdminAppsScript('my-app')
->withInlineScript('my-app', 'window.MyApp = ' . json_encode([...]) . ';', 'before');
\`\`\`

The inline would never reach the browser, so globals (nonces, config) came through as \`undefined\`. Found while testing the Mantine boilerplate Table tab (\"Cannot read properties of undefined (reading 'nonce')\").

## Test plan
- [ ] Load WPKirk-Mantine-Boilerplate admin page → confirm \`window.WPKirkMantine\` is defined in console
- [ ] Click Table tab → data table populates with users (no nonce error)
- [ ] Visual check on other boilerplates (WPKirk-Boilerplate, ReactJS, TypeScript) — no regressions on existing scripts