### PR TITLE
📝 docs(bones): align migrate:v2 docblock with pnpm-lock.yaml removal

### DIFF
--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -3272,7 +3272,7 @@ namespace Bones {
      * webpack infrastructure.
      *
      * The migration:
-     *  - Deletes gulpfile.js and package-lock.json (switching to yarn)
+     *  - Deletes gulpfile.js, package-lock.json and pnpm-lock.yaml (switching to yarn)
      *  - Creates webpack.config.js, tsconfig.json, .prettierrc, jest.config.js
      *  - Rewrites package.json scripts to the unified dev/build/test/format block
      *  - Drops gulp-* and npm-run-all devDependencies


### PR DESCRIPTION
## Summary
- Follow-up a #74: il comando `migrate:v2` ora cancella anche `pnpm-lock.yaml`, ma la docblock del metodo elencava ancora solo `gulpfile.js` e `package-lock.json`.
- Allineata la docblock alla lista effettiva dei file rimossi.

## Test plan
- [ ] Nessun cambiamento funzionale: è solo un commento PHPDoc.