### PR TITLE
🙈 chore(gitignore): ignore local POST.md announcement file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 release.sh
 vendor/
 .idea/
+
+# Announcement post (local only)
+POST.md


### PR DESCRIPTION
## Summary
- Aggiunge `POST.md` a `.gitignore`: è il file di annuncio generato localmente dallo skill `announce-wpbones-plugin` e non deve finire nel repo.

## Test plan
- [ ] Nessun cambiamento funzionale.