### PR TITLE
🐛 fix(bones): address Copilot follow-ups from v2.0.2 boilerplate reviews

### DIFF
--- a/src/Console/bin/bones
+++ b/src/Console/bin/bones
@@ -708,7 +708,7 @@ namespace Bones {
   define('WPBONES_MINIMAL_PHP_VERSION', '7.4');
 
   /* MARK: The WP Bones command line version. */
-  define('WPBONES_COMMAND_LINE_VERSION', '2.0.0');
+  define('WPBONES_COMMAND_LINE_VERSION', '2.0.3');
 
   use Bones\SemVer\Exceptions\InvalidVersionException;
   use Bones\SemVer\Version;
@@ -965,9 +965,15 @@ namespace Bones {
      */
     protected function detectProjectPackageManager(): string
     {
-      if (file_exists('yarn.lock'))          return 'yarn';
-      if (file_exists('pnpm-lock.yaml'))     return 'pnpm';
-      if (file_exists('package-lock.json'))  return 'npm';
+      if (file_exists('yarn.lock')) {
+        return 'yarn';
+      }
+      if (file_exists('pnpm-lock.yaml')) {
+        return 'pnpm';
+      }
+      if (file_exists('package-lock.json')) {
+        return 'npm';
+      }
       return 'yarn';
     }
 
@@ -3468,7 +3474,7 @@ namespace Bones {
       $this->line(" 3. {$testCmd}      # verify tests still pass, if any");
       $this->line('');
       if ($projectPm !== 'yarn') {
-        $this->line("(Detected {$projectPm} lockfile — switch to yarn anytime by deleting your lockfile and running `yarn install`.)");
+        $this->line("(Your {$projectPm} lockfile was removed during migration. To switch to yarn, run `yarn install` instead of step 1.)");
         $this->line('');
       }
 


### PR DESCRIPTION
## Summary

Three small issues surfaced while Copilot reviewed the v2.0.2 rollout PRs across the 14 boilerplates (#77). All three are patched here so the next boilerplate batch picks them up cleanly under v2.0.3.

### 1. 🔴 Misleading post-migration hint (7 PRs flagged this)

**Before:**
```
(Detected pnpm lockfile — switch to yarn anytime by deleting your lockfile and running `yarn install`.)
```

The line is printed *after* `migrate:to-v2` has already deleted `package-lock.json` / `pnpm-lock.yaml`, so telling the user to "delete your lockfile" is impossible guidance.

**After:**
```
(Your pnpm lockfile was removed during migration. To switch to yarn, run `yarn install` instead of step 1.)
```

### 2. 🔴 `WPBONES_COMMAND_LINE_VERSION` out of date (1 PR flagged this)

The constant was still `'2.0.0'` despite the v2.0.1 and v2.0.2 tags. `php bones --version` was reporting the wrong version. Bumped to `'2.0.3'` here.

### 3. 🟡 Style inconsistency in `detectProjectPackageManager()` (6 PRs flagged this)

Rewritten from compact one-liners with aligned spacing to multi-line braced `if` blocks, matching the style used elsewhere in `bones`. Functionally identical.

### Not applied (1 comment)

Copilot (PRs #4/#3 on ReactJS/Cron) suggested anchoring `file_exists()` calls to `__DIR__` to avoid cwd drift. Not applied because `bones` CLI assumes cwd = plugin root by contract (every other lockfile/config lookup in this file uses relative paths). A partial fix only on the new helpers would introduce inconsistency; the broader question is a separate refactor.

## Next steps

- Merge → tag `v2.0.3` → GitHub release
- Close the 14 v2.0.2 boilerplate PRs and rerun the batch with `chore/bones-v2.0.3`
- Regenerate the 16 ZIPs on `docs/public/*.zip`

Refs #77